### PR TITLE
complete Actix 4.11 upgrade, fix clippy warnings, and consolidate dep…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "hoodik"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,13 +21,13 @@ dependencies = [
 
 [[package]]
 name = "actix-cors"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
+checksum = "daa239b93927be1ff123eebada5a3ff23e89f0124ccb8609234e5103d5a5ae6d"
 dependencies = [
  "actix-utils",
  "actix-web",
- "derive_more",
+ "derive_more 2.0.1",
  "futures-util",
  "log",
  "once_cell",
@@ -36,24 +36,24 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.9.0"
+version = "3.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48f96fc3003717aeb9856ca3d02a8c7de502667ad76eeacd830b48d2e91fac4"
+checksum = "7926860314cbe2fb5d1f13731e387ab43bd32bca224e82e6e2db85de0a3dba49"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash 0.8.11",
  "base64 0.22.1",
  "bitflags 2.6.0",
  "brotli",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 2.0.1",
  "encoding_rs",
  "flate2",
+ "foldhash",
  "futures-core",
  "h2",
  "http",
@@ -65,7 +65,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.9.2",
  "sha1 0.10.6",
  "smallvec",
  "tokio",
@@ -86,15 +86,14 @@ dependencies = [
 
 [[package]]
 name = "actix-multipart"
-version = "0.6.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d974dd6c4f78d102d057c672dcf6faa618fafa9df91d44f9c466688fc1275a3a"
+checksum = "d5118a26dee7e34e894f7e85aa0ee5080ae4c18bf03c0e30d49a80e418f00a53"
 dependencies = [
  "actix-multipart-derive",
  "actix-utils",
  "actix-web",
- "bytes",
- "derive_more",
+ "derive_more 0.99.18",
  "futures-core",
  "futures-util",
  "httparse",
@@ -112,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "actix-multipart-derive"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0a77f836d869f700e5b47ac7c3c8b9c8bc82e4aec861954c6198abee3ebd4d"
+checksum = "e11eb847f49a700678ea2fa73daeb3208061afa2b9d1a8527c03390f4c4a1c6b"
 dependencies = [
  "darling 0.20.10",
  "parse-size",
@@ -150,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca2549781d8dd6d75c40cf6b6051260a2cc2f3c62343d761a969a0640646894"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -207,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.9.0"
+version = "4.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9180d76e5cc7ccbc4d60a506f2c727730b154010262df5b910eb17dbe4b8cb38"
+checksum = "a597b77b5c6d6a1e1097fddde329a83665e25c5437c696a3a9a4aa514a614dea"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -221,13 +220,13 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.8.11",
  "bytes",
  "bytestring",
  "cfg-if",
  "cookie",
- "derive_more",
+ "derive_more 2.0.1",
  "encoding_rs",
+ "foldhash",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -245,6 +244,7 @@ dependencies = [
  "smallvec",
  "socket2 0.5.7",
  "time",
+ "tracing",
  "url",
 ]
 
@@ -258,15 +258,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
-]
-
-[[package]]
-name = "addr2line"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
-dependencies = [
- "gimli",
 ]
 
 [[package]]
@@ -447,7 +438,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
 dependencies = [
- "object 0.32.2",
+ "object",
 ]
 
 [[package]]
@@ -681,21 +672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object 0.36.4",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "base32"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -869,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1452,6 +1428,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1705,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,9 +1727,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1912,10 +1915,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.0"
+name = "getrandom"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
 
 [[package]]
 name = "glob"
@@ -1950,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -2317,16 +2326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -2879,19 +2878,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.20.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oncemutex"
@@ -3080,9 +3070,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -3404,6 +3394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73"
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3434,6 +3430,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3454,6 +3460,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3469,6 +3485,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3764,12 +3789,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -4890,27 +4909,26 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2 0.6.1",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5134,6 +5152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5163,13 +5187,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna 1.1.0",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -5281,6 +5306,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasite"
@@ -5515,6 +5549,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5718,6 +5761,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,8 @@ google-authenticator = "0.3.0"
 bcrypt = "^0.14"
 qstring = "^0.7"
 openssl = { version = "0.10", features = ["vendored"] }
+
+[workspace.lints.rust.unexpected_cfgs]
+# Allow wasm-bindgen internal cfg flags used by macros
+level = "warn"
+check-cfg = ["cfg(wasm_bindgen_unstable_test_coverage)"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,72 @@ members = [
   "storage",
   "util",
 ]
+
+[workspace.dependencies]
+# Actix ecosystem
+actix-web = "^4.11"
+actix-cors = "^0.7"
+actix-multipart = "^0.7"
+
+# Async runtime
+tokio = "^1"
+async-trait = "0.1.57"
+futures = "^0.3"
+futures-util = "^0.3"
+async-std = { version = "^1", features = ["attributes", "tokio1"] }
+
+# Serialization
+serde = { version = "^1", features = ["derive"] }
+serde_json = "^1"
+
+# Logging
+log = "^0.4"
+env_logger = "^0.10"
+
+# Date/time
+chrono = { version = "0.4.23", features = ["serde"] }
+
+# Validation
+validr = "^0.3"
+
+# Database
+sea-orm = { version = "^0.12", features = ["sqlx-postgres", "sqlx-sqlite", "runtime-actix-rustls", "macros"] }
+sea-orm-migration = { version = "^0.12", features = ["sqlx-postgres", "sqlx-sqlite", "runtime-actix-rustls"] }
+
+# Crypto & security
+rustls = "^0.20"
+rustls-pemfile = "^1"
+rcgen = "^0.10"
+rsa = { version = "^0.8", features = ["sha2"] }
+base64 = "^0.21"
+hex = "^0.4"
+jsonwebtoken = "^8"
+
+# HTTP client
+reqwest = "^0.11"
+
+# Utilities
+uuid = { version = "1.2.2", features = ["serde", "v4"] }
+url = "^2"
+glob = "^0.3"
+num-traits = "0.2"
+
+# Email
+lettre = "0.11"
+handlebars = "^4"
+
+# Other
+thiserror = "^1"
+dotenv = "^0.15"
+clap = { version = "^4", features = ["string"] }
+path-absolutize = "^3"
+fs4 = "^0.6"
+pin-project = "^1"
+cached = "^0.43"
+strum = "0.24"
+strum_macros = "0.24"
+zxcvbn = "2.2.1"
+google-authenticator = "0.3.0"
+bcrypt = "^0.14"
+qstring = "^0.7"
+openssl = { version = "0.10", features = ["vendored"] }

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -2,19 +2,20 @@
 name = "admin"
 version = "1.0.1"
 edition = "2021"
+rust-version = "1.91"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = "^0.4"
-actix-web = "^4"
-validr = "^0.3"
-serde = "^1"
-serde_json = "^1"
-strum = "0.24"
-strum_macros = "0.24"
-chrono = { version = "^0.4", features = ["serde"] }
-num-traits = "0.2"
+log = { workspace = true }
+actix-web = { workspace = true }
+validr = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+chrono = { workspace = true }
+num-traits = { workspace = true }
 
 auth = { path = "../auth" }
 context = { path = "../context" }
@@ -25,6 +26,6 @@ settings = { path = "../settings" }
 util = { path = "../util" }
 
 [dev-dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { workspace = true }
 entity = { path = "../entity", features = ["mock"] }
 context = { path = "../context", features = ["mock"] }

--- a/admin/src/tests/invitations.rs
+++ b/admin/src/tests/invitations.rs
@@ -71,7 +71,7 @@ async fn test_expire_invitation() {
     let invitations = paginated.data;
 
     assert_eq!(invitations.len(), 1);
-    let invitation = invitations.get(0).unwrap();
+    let invitation = invitations.first().unwrap();
 
     repository
         .invitations()

--- a/admin/src/tests/mod.rs
+++ b/admin/src/tests/mod.rs
@@ -7,13 +7,13 @@ mod invitations;
 mod sessions;
 mod users;
 
-pub(crate) async fn get_repo<'ctx>(context: &'ctx Context) -> Repository<'ctx, DatabaseConnection> {
-    let repository = Repository::new(&context, &context.db);
+pub(crate) async fn get_repo(context: &Context) -> Repository<'_, DatabaseConnection> {
+    let repository = Repository::new(context, &context.db);
 
     repository
 }
 
-pub(crate) async fn get_users<'ctx>(context: &'ctx Context) -> Vec<entity::users::Model> {
+pub(crate) async fn get_users(context: &Context) -> Vec<entity::users::Model> {
     let mut users = vec![];
 
     users.push(entity::mock::create_user(&context.db, "1@test.com", None).await);
@@ -29,8 +29,8 @@ pub(crate) async fn get_users<'ctx>(context: &'ctx Context) -> Vec<entity::users
     users
 }
 
-pub(crate) async fn create_sessions<'ctx>(
-    context: &'ctx Context,
+pub(crate) async fn create_sessions(
+    context: &Context,
     user: &entity::users::Model,
 ) -> Vec<entity::sessions::Model> {
     let mut sessions = vec![];
@@ -38,7 +38,7 @@ pub(crate) async fn create_sessions<'ctx>(
     sessions.push(
         entity::mock::create_session(
             &context.db,
-            &user,
+            user,
             Some("123.123.123.1"),
             Some("Mozilla Something?"),
             false,
@@ -48,7 +48,7 @@ pub(crate) async fn create_sessions<'ctx>(
     sessions.push(
         entity::mock::create_session(
             &context.db,
-            &user,
+            user,
             Some("123.123.123.2"),
             Some("Chrome Something?"),
             false,
@@ -58,7 +58,7 @@ pub(crate) async fn create_sessions<'ctx>(
     sessions.push(
         entity::mock::create_session(
             &context.db,
-            &user,
+            user,
             Some("123.123.123.3"),
             Some("Edge Something?"),
             false,
@@ -68,7 +68,7 @@ pub(crate) async fn create_sessions<'ctx>(
     sessions.push(
         entity::mock::create_session(
             &context.db,
-            &user,
+            user,
             Some("123.123.123.4"),
             Some("Brave Something?"),
             false,
@@ -78,7 +78,7 @@ pub(crate) async fn create_sessions<'ctx>(
     sessions.push(
         entity::mock::create_session(
             &context.db,
-            &user,
+            user,
             Some("123.123.123.5"),
             Some("Safari Something?"),
             false,

--- a/admin/src/tests/sessions.rs
+++ b/admin/src/tests/sessions.rs
@@ -5,7 +5,7 @@ use context::Context;
 async fn test_find_sessions() {
     let context = Context::mock_sqlite().await;
     let repository = crate::tests::get_repo(&context).await;
-    let user = super::get_users(&context).await.get(0).unwrap().clone();
+    let user = super::get_users(&context).await.first().unwrap().clone();
     let _sessions = super::create_sessions(&context, &user).await;
 
     let paginated = repository
@@ -30,7 +30,7 @@ async fn test_find_sessions() {
 async fn test_find_sessions_by_ip() {
     let context = Context::mock_sqlite().await;
     let repository = crate::tests::get_repo(&context).await;
-    let user = super::get_users(&context).await.get(0).unwrap().clone();
+    let user = super::get_users(&context).await.first().unwrap().clone();
     let _sessions = super::create_sessions(&context, &user).await;
 
     let paginated = repository
@@ -56,7 +56,7 @@ async fn test_find_sessions_by_email() {
     let context = Context::mock_sqlite().await;
     let repository = crate::tests::get_repo(&context).await;
     let users = super::get_users(&context).await;
-    let user = users.get(0).unwrap().clone();
+    let user = users.first().unwrap().clone();
     let user2 = users.get(1).unwrap().clone();
 
     let _sessions = super::create_sessions(&context, &user).await;
@@ -92,7 +92,7 @@ async fn test_find_sessions_by_email() {
 async fn test_find_sessions_by_user_agent() {
     let context = Context::mock_sqlite().await;
     let repository = crate::tests::get_repo(&context).await;
-    let user = super::get_users(&context).await.get(0).unwrap().clone();
+    let user = super::get_users(&context).await.first().unwrap().clone();
     let _sessions = super::create_sessions(&context, &user).await;
 
     let paginated = repository
@@ -117,12 +117,12 @@ async fn test_find_sessions_by_user_agent() {
 async fn test_session_killing() {
     let context = Context::mock_sqlite().await;
     let repository = crate::tests::get_repo(&context).await;
-    let user = super::get_users(&context).await.get(0).unwrap().clone();
+    let user = super::get_users(&context).await.first().unwrap().clone();
     let sessions = super::create_sessions(&context, &user).await;
 
-    let session = sessions.get(0).unwrap().clone();
+    let session = sessions.first().unwrap().clone();
 
-    let _ = repository.sessions().kill(session.id).await.unwrap();
+    repository.sessions().kill(session.id).await.unwrap();
 
     let paginated = repository
         .sessions()

--- a/admin/src/tests/users.rs
+++ b/admin/src/tests/users.rs
@@ -100,7 +100,7 @@ async fn test_find_all_users_and_properly_add_session() {
     let repository = super::get_repo(&context).await;
     let users = super::get_users(&context).await;
 
-    let user = users.get(0).unwrap().clone();
+    let user = users.first().unwrap().clone();
     entity::mock::create_session(&context.db, &user, None, None, true).await;
     entity::mock::create_session(&context.db, &user, None, None, true).await;
     entity::mock::create_session(&context.db, &user, None, None, true).await;
@@ -131,7 +131,7 @@ async fn test_delete_user() {
     let context = Context::mock_sqlite().await;
     let repository = super::get_repo(&context).await;
     let users = super::get_users(&context).await;
-    let user = users.get(0).unwrap().clone();
+    let user = users.first().unwrap().clone();
 
     repository.users().delete(user.id).await.unwrap();
 }

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -2,6 +2,7 @@
 name = "auth"
 version = "1.1.0"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]
 readme = "README.md"
 license-file = "../LICENSE.md"
@@ -17,15 +18,15 @@ path = "src/lib.rs"
 mock = []
 
 [dependencies]
-async-trait = "0.1.57"
-validr = "^0.3"
-chrono = { version = "0.4.23", features = ["serde"] }
-log = "^0.4"
-actix-web = "^4"
-futures-util = "^0.3"
-jsonwebtoken = "^8"
-serde = "^1"
-serde_json = "^1"
+async-trait = { workspace = true }
+validr = { workspace = true }
+chrono = { workspace = true }
+log = { workspace = true }
+actix-web = { workspace = true }
+futures-util = { workspace = true }
+jsonwebtoken = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 context = { path = "../context" }
 error = { path = "../error" }
@@ -34,7 +35,7 @@ util = { path = "../util" }
 cryptfns = { path = "../cryptfns" }
 
 [dev-dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { workspace = true }
 
 context = { path = "../context", features = ["mock"] }
 entity = { path = "../entity", features = ["mock"] }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -2,6 +2,7 @@
 name = "config"
 version = "1.2.0"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]
 readme = "README.md"
 license-file = "../LICENSE.md"
@@ -17,14 +18,14 @@ path = "src/lib.rs"
 mock = []
 
 [dependencies]
-url = "^2"
-dotenv = "^0.15"
-uuid = "^1"
-rustls = "^0.20"
-rustls-pemfile = "^1"
-rcgen = "^0.10"
-log = "^0.4"
-chrono = { version = "0.4.23", features = ["serde"] }
+url = { workspace = true }
+dotenv = { workspace = true }
+uuid = { workspace = true }
+rustls = { workspace = true }
+rustls-pemfile = { workspace = true }
+rcgen = { workspace = true }
+log = { workspace = true }
+chrono = { workspace = true }
 error = { path = "../error" }
-clap = { version = "^4", features = ["string"] }
-path-absolutize = "^3"
+clap = { workspace = true }
+path-absolutize = { workspace = true }

--- a/config/src/email.rs
+++ b/config/src/email.rs
@@ -119,7 +119,7 @@ impl SmtpCredentials {
         };
 
         // Check if using deprecated SMTP_DEFAULT_FROM (peek without consuming)
-        let used_deprecated_default_from = !default_from_email.is_some() && smtp_default_from.is_some();
+        let used_deprecated_default_from = default_from_email.is_none() && smtp_default_from.is_some();
         
         if used_deprecated_default_from {
             vars.add_warning(
@@ -134,11 +134,11 @@ impl SmtpCredentials {
             let default_from = match (default_from_email.maybe_get(), default_from_name.maybe_get()) {
                 (Some(email), Some(name)) if !email.is_empty() && !name.is_empty() => {
                     // Both email and name provided: format as "Name <email@example.com>"
-                    format!("{} <{}>", name, email)
+                    format!("{name} <{email}>")
                 }
                 (Some(email), _) if !email.is_empty() => {
                     // Only email provided
-                    format!("Hoodik <{}>", email)
+                    format!("Hoodik <{email}>")
                 }
                 _ => {
                     // Fall back to deprecated SMTP_DEFAULT_FROM

--- a/config/src/vars.rs
+++ b/config/src/vars.rs
@@ -8,6 +8,9 @@ impl<T> GetterType for T where T: FromStr + Clone + Send + Sync + 'static {}
 
 pub(crate) trait OptionLike {
     fn is_some(&self) -> bool;
+    fn is_none(&self) -> bool {
+        !self.is_some()
+    }
 }
 
 pub(crate) struct Var<T: GetterType>(Option<T>);
@@ -43,6 +46,9 @@ where
 {
     fn is_some(&self) -> bool {
         self.inner.is_some()
+    }
+    fn is_none(&self) -> bool {
+        self.inner.is_none()
     }
 }
 

--- a/context/Cargo.toml
+++ b/context/Cargo.toml
@@ -2,6 +2,7 @@
 name = "context"
 version = "1.0.0"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]
 readme = "README.md"
 license-file = "../LICENSE.md"
@@ -23,15 +24,15 @@ mock = [
 ]
 
 [dependencies]
-actix-web = "^4"
-sea-orm = { version = "^0.12", features = [
+actix-web = { workspace = true }
+sea-orm = { workspace = true, features = [
   "sqlx-postgres",
   "sqlx-sqlite",
   "runtime-actix-rustls",
   "macros",
 ] }
-log = "^0.4"
-env_logger = "^0.10"
+log = { workspace = true }
+env_logger = { workspace = true }
 
 config = { path = "../config" }
 email = { path = "../email" }

--- a/cryptfns/Cargo.toml
+++ b/cryptfns/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cryptfns"
 version = "1.0.2"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]
 license-file = "../LICENSE.md"
 repository = "https://github.com/htunlogic/hoodik"
@@ -19,12 +20,12 @@ mock = []
 
 [dependencies]
 rand = "^0.8"
-rsa = { version = "^0.8", features = ["sha2"] }
+rsa = { workspace = true }
 sha256 = { version = "^1", default-features = false }
-base64 = "^0.21"
-hex = "^0.4"
-serde = "^1"
-serde_json = "^1"
+base64 = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 wasm-bindgen = "0.2.63"
 getrandom = { version = "^0.2", features = ["js"] }
 ascon-aead = "^0.4"
@@ -39,11 +40,7 @@ chacha20poly1305 = "0.10.1"
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6", optional = true }
-
-[dependencies.num-traits]
-version = "0.2.9"
-features = ["libm"]
-default-features = false
+num-traits = { version = "0.2.9", features = ["libm"], default-features = false }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/cryptfns/Cargo.toml
+++ b/cryptfns/Cargo.toml
@@ -44,3 +44,8 @@ num-traits = { version = "0.2.9", features = ["libm"], default-features = false 
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
+
+[lints.rust.unexpected_cfgs]
+# Allow wasm-bindgen internal cfg flags used by the macro
+level = "warn"
+check-cfg = ["cfg(wasm_bindgen_unstable_test_coverage)"]

--- a/email/Cargo.toml
+++ b/email/Cargo.toml
@@ -2,6 +2,7 @@
 name = "email"
 version = "1.0.0"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]
 readme = "README.md"
 license-file = "../LICENSE.md"
@@ -16,10 +17,10 @@ mock = []
 [dependencies]
 error = { path = "../error" }
 config = { path = "../config" }
-lettre = "0.11"
-log = "^0.4"
-handlebars = "^4"
-serde = "^1"
-serde_json = "^1"
-async-trait = "^0.1"
-tokio = "^1"
+lettre = { workspace = true }
+log = { workspace = true }
+handlebars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -2,6 +2,7 @@
 name = "entity"
 version = "1.1.0"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]
 readme = "README.md"
 license-file = "../LICENSE.md"
@@ -17,17 +18,17 @@ path = "src/lib.rs"
 mock = ["sea-orm/mock", "cryptfns"]
 
 [dependencies]
-num-traits = "^0.2"
-sea-orm = { version = "^0.12", features = [
+num-traits = { workspace = true }
+sea-orm = { workspace = true, features = [
   "sqlx-postgres",
   "sqlx-sqlite",
   "runtime-actix-rustls",
   "macros",
   "bigdecimal",
 ] }
-chrono = { version = "0.4.23", features = ["serde"] }
-serde = "^1"
-serde_json = "^1"
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 fs = { path = "../fs" }
 error = { path = "../error" }
 util = { path = "../util" }

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -2,6 +2,7 @@
 name = "error"
 version = "1.0.1"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]
 readme = "README.md"
 license-file = "../LICENSE.md"
@@ -14,27 +15,27 @@ name = "error"
 path = "src/lib.rs"
 
 [dependencies]
-thiserror = "^1"
-sea-orm = { version = "^0.12", features = [
+thiserror = { workspace = true }
+sea-orm = { workspace = true, features = [
   "sqlx-postgres",
   "sqlx-sqlite",
   "runtime-actix-rustls",
 ] }
-validr = "^0.3"
-actix-multipart = "^0.6"
-actix-web = "^4"
-rsa = "^0.8"
-base64 = "^0.21"
-hex = "^0.4"
-jsonwebtoken = "^8"
-reqwest = "^0.11"
-serde = "^1"
-serde_json = "^1"
-glob = "^0.3"
-rcgen = "^0.10"
-uuid = { version = "1.2.2", features = ["serde", "v4"] }
-rustls = "^0.20"
-lettre = "^0.11"
-handlebars = "^4"
+validr = { workspace = true }
+actix-multipart = { workspace = true }
+actix-web = { workspace = true }
+rsa = { workspace = true }
+base64 = { workspace = true }
+hex = { workspace = true }
+jsonwebtoken = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+glob = { workspace = true }
+rcgen = { workspace = true }
+uuid = { workspace = true }
+rustls = { workspace = true }
+lettre = { workspace = true }
+handlebars = { workspace = true }
 
 cryptfns = { path = "../cryptfns" }

--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fs"
 version = "1.0.0"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]
 readme = "README.md"
 license-file = "../LICENSE.md"
@@ -13,12 +14,12 @@ description = "File system abstraction library"
 config = { path = "../config" }
 error = { path = "../error" }
 
-fs4 = "^0.6"
-log = "^0.4"
-actix-web = "^4"
-futures-util = "^0.3"
-glob = "^0.3"
-pin-project = "^1"
-tokio = "^1"
-async-trait = "^0.1"
-chrono = "^0.4"
+fs4 = { workspace = true }
+log = { workspace = true }
+actix-web = { workspace = true }
+futures-util = { workspace = true }
+glob = { workspace = true }
+pin-project = { workspace = true }
+tokio = { workspace = true }
+async-trait = { workspace = true }
+chrono = { workspace = true }

--- a/hoodik/Cargo.toml
+++ b/hoodik/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hoodik"
 version = "1.7.0"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]
 readme = "../README.md"
 license-file = "../LICENSE.md"
@@ -11,14 +12,14 @@ default-run = "hoodik"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
-log = "^0.4"
-env_logger = "^0.10"
-actix-web = { version = "^4", features = ["rustls"] }
-actix-cors = "0.6.3"
-reqwest = "^0.11"
-serde = "^1"
-serde_json = "^1"
+openssl = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
+actix-web = { workspace = true, features = ["rustls"] }
+actix-cors = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 admin = { path = "../admin" }
 auth = { path = "../auth" }
@@ -33,7 +34,7 @@ migration = { path = "../migration" }
 storage = { path = "../storage" }
 
 [dev-dependencies]
-chrono = { version = "0.4.23", features = ["serde"] }
+chrono = { workspace = true }
 auth = { path = "../auth", features = ["mock"] }
 context = { path = "../context", features = ["mock"] }
 cryptfns = { path = "../cryptfns", features = ["mock"] }

--- a/hoodik/Cargo.toml
+++ b/hoodik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoodik"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]

--- a/hoodik/tests/links.rs
+++ b/hoodik/tests/links.rs
@@ -21,7 +21,7 @@ async fn test_creating_and_downloading_link() {
 
     let encrypted_secret = "some-random-encrypted-secret".to_string();
 
-    let mut app = test::init_service(server::app(context.clone())).await;
+    let app = test::init_service(server::app(context.clone())).await;
 
     let req = test::TestRequest::post()
         .uri("/api/auth/register")
@@ -37,8 +37,8 @@ async fn test_creating_and_downloading_link() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
-    let (jwt, _) = helpers::extract_cookies(&resp.headers());
+    let resp = test::call_service(&app, req).await;
+    let (jwt, _) = helpers::extract_cookies(resp.headers());
     let jwt = jwt.unwrap();
 
     let (data, size, checksum) = create_byte_chunks();
@@ -68,7 +68,7 @@ async fn test_creating_and_downloading_link() {
         .set_json(&random_file)
         .to_request();
 
-    let body = test::call_and_read_body(&mut app, req).await;
+    let body = test::call_and_read_body(&app, req).await;
     // let string_body = String::from_utf8(body.to_vec()).unwrap();
     // println!("string_body: {}", string_body);
 
@@ -95,7 +95,7 @@ async fn test_creating_and_downloading_link() {
             .set_payload(chunk)
             .to_request();
 
-        let body = test::call_and_read_body(&mut app, req).await;
+        let body = test::call_and_read_body(&app, req).await;
         // let string_body = String::from_utf8(body.to_vec()).unwrap();
         // println!("string_body: {}", string_body);
 
@@ -138,7 +138,7 @@ async fn test_creating_and_downloading_link() {
         .set_json(create_link)
         .to_request();
 
-    let body = test::call_and_read_body(&mut app, req).await;
+    let body = test::call_and_read_body(&app, req).await;
     let link: AppLink = serde_json::from_slice(&body).unwrap();
 
     let download_linked_file = links::data::download::Download {
@@ -151,7 +151,7 @@ async fn test_creating_and_downloading_link() {
         // .cookie(jwt.clone()) - no need for jwt, this should be public
         .to_request();
 
-    let contents = test::call_and_read_body(&mut app, req).await.to_vec();
+    let contents = test::call_and_read_body(&app, req).await.to_vec();
     // let string_body = String::from_utf8(contents.to_vec()).unwrap();
     // println!("string_body: {}", string_body);
 
@@ -168,7 +168,7 @@ async fn test_creating_and_downloading_link() {
         .to_request();
 
     let file =
-        serde_json::from_slice::<AppFile>(&test::call_and_read_body(&mut app, req).await).unwrap();
+        serde_json::from_slice::<AppFile>(&test::call_and_read_body(&app, req).await).unwrap();
 
     // println!("file: {:#?}", file);
 

--- a/hoodik/tests/storage.rs
+++ b/hoodik/tests/storage.rs
@@ -21,7 +21,7 @@ async fn test_creating_file_and_uploading_chunks() {
 
     let encrypted_secret = "some-random-encrypted-secret".to_string();
 
-    let mut app = test::init_service(server::app(context.clone())).await;
+    let app = test::init_service(server::app(context.clone())).await;
 
     let req = test::TestRequest::post()
         .uri("/api/auth/register")
@@ -37,8 +37,8 @@ async fn test_creating_file_and_uploading_chunks() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
-    let (jwt, _) = helpers::extract_cookies(&resp.headers());
+    let resp = test::call_service(&app, req).await;
+    let (jwt, _) = helpers::extract_cookies(resp.headers());
     let jwt = jwt.unwrap();
 
     let req = test::TestRequest::post()
@@ -55,8 +55,8 @@ async fn test_creating_file_and_uploading_chunks() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
-    let (second_jwt, _) = helpers::extract_cookies(&resp.headers());
+    let resp = test::call_service(&app, req).await;
+    let (second_jwt, _) = helpers::extract_cookies(resp.headers());
     let second_jwt = second_jwt.unwrap();
 
     let (mut data, mut size, _) = create_byte_chunks();
@@ -70,7 +70,7 @@ async fn test_creating_file_and_uploading_chunks() {
 
     data.push(another);
 
-    size = size + (CHUNK_SIZE_BYTES / 2) as i64;
+    size += (CHUNK_SIZE_BYTES / 2) as i64;
 
     let checksum = calculate_checksum(data.clone());
 
@@ -98,7 +98,7 @@ async fn test_creating_file_and_uploading_chunks() {
         .set_json(&random_file)
         .to_request();
 
-    let body = test::call_and_read_body(&mut app, req).await;
+    let body = test::call_and_read_body(&app, req).await;
     // let string_body = String::from_utf8(body.to_vec()).unwrap();
     // println!("string_body: {}", string_body);
 
@@ -123,7 +123,7 @@ async fn test_creating_file_and_uploading_chunks() {
             .set_payload(chunk)
             .to_request();
 
-        let body = test::call_and_read_body(&mut app, req).await;
+        let body = test::call_and_read_body(&app, req).await;
 
         file = match serde_json::from_slice(&body) {
             Ok(f) => f,
@@ -150,7 +150,7 @@ async fn test_creating_file_and_uploading_chunks() {
         .cookie(jwt.clone())
         .to_request();
 
-    let contents = test::call_and_read_body(&mut app, req).await.to_vec();
+    let contents = test::call_and_read_body(&app, req).await.to_vec();
 
     let content_len = contents.len();
     let file_checksum = cryptfns::sha256::digest(contents.as_slice());
@@ -176,7 +176,7 @@ async fn test_creating_file_and_uploading_chunks() {
         .set_json(&random_file)
         .to_request();
 
-    let response = test::call_service(&mut app, req).await;
+    let response = test::call_service(&app, req).await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     // Owner can see it
@@ -186,7 +186,7 @@ async fn test_creating_file_and_uploading_chunks() {
         .set_json(&random_file)
         .to_request();
 
-    let response = test::call_service(&mut app, req).await;
+    let response = test::call_service(&app, req).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     context.config.app.cleanup();

--- a/hoodik/tests/web_authentication.rs
+++ b/hoodik/tests/web_authentication.rs
@@ -26,7 +26,7 @@ async fn test_registration_and_login() {
 
     let encrypted_secret = "some-random-encrypted-secret".to_string();
 
-    let mut app = test::init_service(server::app(context.clone())).await;
+    let app = test::init_service(server::app(context.clone())).await;
 
     let req = test::TestRequest::post()
         .uri("/api/auth/register")
@@ -42,7 +42,7 @@ async fn test_registration_and_login() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), StatusCode::CREATED);
 
@@ -55,7 +55,7 @@ async fn test_registration_and_login() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), StatusCode::OK);
 
@@ -70,8 +70,8 @@ async fn test_registration_and_login() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
-    let (jwt, refresh) = helpers::extract_cookies(&resp.headers());
+    let resp = test::call_service(&app, req).await;
+    let (jwt, refresh) = helpers::extract_cookies(resp.headers());
 
     assert_eq!(resp.status(), StatusCode::OK);
     // println!("{:?}", &resp.headers());
@@ -84,10 +84,10 @@ async fn test_registration_and_login() {
         .cookie(refresh.unwrap())
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
 
-    let (jwt, _refresh) = helpers::extract_cookies(&resp.headers());
+    let (jwt, _refresh) = helpers::extract_cookies(resp.headers());
 
     // let body = test::read_body(resp).await;
     // let body_str = String::from_utf8_lossy(&body).to_string();
@@ -100,7 +100,7 @@ async fn test_registration_and_login() {
         .cookie(jwt.clone().unwrap())
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
 
     assert_eq!(status, StatusCode::OK);
@@ -110,9 +110,9 @@ async fn test_registration_and_login() {
         .cookie(jwt.clone().unwrap())
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
-    let (jwt, refresh) = helpers::extract_cookies(&resp.headers());
+    let (jwt, refresh) = helpers::extract_cookies(resp.headers());
 
     // let body = test::read_body(resp).await;
     // let body_str = String::from_utf8_lossy(&body).to_string();
@@ -146,7 +146,7 @@ async fn test_register_and_verify_user_email() {
 
     let encrypted_secret = "some-random-encrypted-secret".to_string();
 
-    let mut app = test::init_service(server::app(context.clone())).await;
+    let app = test::init_service(server::app(context.clone())).await;
 
     let req = test::TestRequest::post()
         .uri("/api/auth/register")
@@ -162,7 +162,7 @@ async fn test_register_and_verify_user_email() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), StatusCode::CREATED);
 
@@ -180,7 +180,7 @@ async fn test_register_and_verify_user_email() {
         .uri(format!("/api/auth/action/activate-email/{id}").as_str())
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), StatusCode::OK);
     let body = test::read_body(resp).await;
@@ -202,7 +202,7 @@ async fn test_claims_can_expire() {
 
     let encrypted_secret = "some-random-encrypted-secret".to_string();
 
-    let mut app = test::init_service(server::app(context.clone())).await;
+    let app = test::init_service(server::app(context.clone())).await;
 
     let req = test::TestRequest::post()
         .uri("/api/auth/register")
@@ -218,8 +218,8 @@ async fn test_claims_can_expire() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
-    let (jwt, _) = helpers::extract_cookies(&resp.headers());
+    let resp = test::call_service(&app, req).await;
+    let (jwt, _) = helpers::extract_cookies(resp.headers());
 
     assert_eq!(resp.status(), StatusCode::CREATED);
 
@@ -230,7 +230,7 @@ async fn test_claims_can_expire() {
         .cookie(jwt.clone().unwrap())
         .to_request();
 
-    let resp = test::try_call_service(&mut app, req).await.unwrap();
+    let resp = test::try_call_service(&app, req).await.unwrap();
 
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
@@ -247,7 +247,7 @@ async fn test_expired_session_can_be_refreshed() {
 
     let encrypted_secret = "some-random-encrypted-secret".to_string();
 
-    let mut app = test::init_service(server::app(context.clone())).await;
+    let app = test::init_service(server::app(context.clone())).await;
 
     let req = test::TestRequest::post()
         .uri("/api/auth/register")
@@ -263,8 +263,8 @@ async fn test_expired_session_can_be_refreshed() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
-    let (jwt, refresh) = helpers::extract_cookies(&resp.headers());
+    let resp = test::call_service(&app, req).await;
+    let (jwt, refresh) = helpers::extract_cookies(resp.headers());
 
     assert_eq!(resp.status(), StatusCode::CREATED);
 
@@ -275,7 +275,7 @@ async fn test_expired_session_can_be_refreshed() {
         .cookie(jwt.clone().unwrap())
         .to_request();
 
-    let resp = test::try_call_service(&mut app, req).await.unwrap();
+    let resp = test::try_call_service(&app, req).await.unwrap();
 
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 
@@ -285,9 +285,9 @@ async fn test_expired_session_can_be_refreshed() {
         .cookie(refresh.clone().unwrap())
         .to_request();
 
-    let resp = test::try_call_service(&mut app, req).await.unwrap();
+    let resp = test::try_call_service(&app, req).await.unwrap();
     let status = resp.status();
-    let (jwt, _) = helpers::extract_cookies(&resp.headers());
+    let (jwt, _) = helpers::extract_cookies(resp.headers());
     // let body = test::read_body(resp).await;
     // let body_str = String::from_utf8_lossy(&body).to_string();
     // println!("{:#?}", body_str);
@@ -299,7 +299,7 @@ async fn test_expired_session_can_be_refreshed() {
         .cookie(jwt.clone().unwrap())
         .to_request();
 
-    let resp = test::try_call_service(&mut app, req).await.unwrap();
+    let resp = test::try_call_service(&app, req).await.unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
 }
@@ -315,7 +315,7 @@ async fn cannot_refresh_logged_out_session() {
 
     let encrypted_secret = "some-random-encrypted-secret".to_string();
 
-    let mut app = test::init_service(server::app(context.clone())).await;
+    let app = test::init_service(server::app(context.clone())).await;
 
     let req = test::TestRequest::post()
         .uri("/api/auth/register")
@@ -331,8 +331,8 @@ async fn cannot_refresh_logged_out_session() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
-    let (jwt, refresh) = helpers::extract_cookies(&resp.headers());
+    let resp = test::call_service(&app, req).await;
+    let (jwt, refresh) = helpers::extract_cookies(resp.headers());
 
     assert_eq!(resp.status(), StatusCode::CREATED);
 
@@ -341,7 +341,7 @@ async fn cannot_refresh_logged_out_session() {
         .cookie(jwt.clone().unwrap())
         .to_request();
 
-    let resp = test::try_call_service(&mut app, req).await.unwrap();
+    let resp = test::try_call_service(&app, req).await.unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
 
@@ -350,7 +350,7 @@ async fn cannot_refresh_logged_out_session() {
         .cookie(jwt.clone().unwrap())
         .to_request();
 
-    let resp = test::try_call_service(&mut app, req).await.unwrap();
+    let resp = test::try_call_service(&app, req).await.unwrap();
     let status = resp.status();
     // let body = test::read_body(resp).await;
     // let body_str = String::from_utf8_lossy(&body).to_string();
@@ -364,7 +364,7 @@ async fn cannot_refresh_logged_out_session() {
         .cookie(refresh.clone().unwrap())
         .to_request();
 
-    let resp = test::try_call_service(&mut app, req).await.unwrap();
+    let resp = test::try_call_service(&app, req).await.unwrap();
     let status = resp.status();
     // let body = test::read_body(resp).await;
     // let body_str = String::from_utf8_lossy(&body).to_string();

--- a/hoodik/tests/web_registration.rs
+++ b/hoodik/tests/web_registration.rs
@@ -26,7 +26,7 @@ async fn test_allow_register_false() {
 
     let encrypted_secret = "some-random-encrypted-secret".to_string();
 
-    let mut app = test::init_service(server::app(context.clone())).await;
+    let app = test::init_service(server::app(context.clone())).await;
 
     let req = test::TestRequest::post()
         .uri("/api/auth/register")
@@ -42,7 +42,7 @@ async fn test_allow_register_false() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }
@@ -72,7 +72,7 @@ async fn test_whitelist_pass_and_fail() {
 
     let encrypted_secret = "some-random-encrypted-secret".to_string();
 
-    let mut app = test::init_service(server::app(context.clone())).await;
+    let app = test::init_service(server::app(context.clone())).await;
 
     let req = test::TestRequest::post()
         .uri("/api/auth/register")
@@ -88,7 +88,7 @@ async fn test_whitelist_pass_and_fail() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
 
@@ -106,7 +106,7 @@ async fn test_whitelist_pass_and_fail() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), StatusCode::CREATED);
 }
@@ -136,7 +136,7 @@ async fn test_registration_allowed_fails_blacklist_cannot_register() {
 
     let encrypted_secret = "some-random-encrypted-secret".to_string();
 
-    let mut app = test::init_service(server::app(context.clone())).await;
+    let app = test::init_service(server::app(context.clone())).await;
 
     let req = test::TestRequest::post()
         .uri("/api/auth/register")
@@ -152,7 +152,7 @@ async fn test_registration_allowed_fails_blacklist_cannot_register() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), StatusCode::CREATED);
 
@@ -170,7 +170,7 @@ async fn test_registration_allowed_fails_blacklist_cannot_register() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }
@@ -205,7 +205,7 @@ async fn test_registration_not_allowed_fails_blacklist_cannot_register() {
 
     let encrypted_secret = "some-random-encrypted-secret".to_string();
 
-    let mut app = test::init_service(server::app(context.clone())).await;
+    let app = test::init_service(server::app(context.clone())).await;
 
     let req = test::TestRequest::post()
         .uri("/api/auth/register")
@@ -221,7 +221,7 @@ async fn test_registration_not_allowed_fails_blacklist_cannot_register() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), StatusCode::CREATED);
 
@@ -239,7 +239,7 @@ async fn test_registration_not_allowed_fails_blacklist_cannot_register() {
         })
         .to_request();
 
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }

--- a/links/Cargo.toml
+++ b/links/Cargo.toml
@@ -2,6 +2,7 @@
 name = "links"
 version = "1.0.0"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]
 readme = "README.md"
 license-file = "../LICENSE.md"
@@ -13,13 +14,13 @@ description = "Application links service that enables users to share public link
 mock = ["context/mock", "entity/mock"]
 
 [dependencies]
-log = "^0.4"
-actix-web = "^4"
-validr = "^0.3"
-serde = "^1"
-serde_json = "^1"
-chrono = "^0.4"
-cached = "^0.43"
+log = { workspace = true }
+actix-web = { workspace = true }
+validr = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+cached = { workspace = true }
 
 auth = { path = "../auth" }
 context = { path = "../context" }

--- a/links/src/test.rs
+++ b/links/src/test.rs
@@ -12,11 +12,11 @@ async fn create_link(
     name: &str,
 ) -> AppLink {
     let (file, _user_file) =
-        entity::mock::create_file(&context.db, &user, name, "application/json", None).await;
+        entity::mock::create_file(&context.db, user, name, "application/json", None).await;
 
     let signature = cryptfns::rsa::private::sign(&file.id.to_string(), private_key_string).unwrap();
 
-    let repository = Repository::new(&context);
+    let repository = Repository::new(context);
 
     let create_link = CreateLink {
         file_id: Some(file.id.to_string()),
@@ -28,7 +28,7 @@ async fn create_link(
         expires_at: None,
     };
 
-    repository.create(create_link, &user).await.unwrap()
+    repository.create(create_link, user).await.unwrap()
 }
 
 #[actix_web::test]

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -2,6 +2,7 @@
 name = "migration"
 version = "1.1.0"
 edition = "2021"
+rust-version = "1.91"
 publish = false
 authors = ["Tibor Hudik <hello@hudik.eu>"]
 readme = "README.md"
@@ -17,10 +18,8 @@ name = "migration"
 path = "src/main.rs"
 
 [dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1"] }
+async-std = { workspace = true }
 
 config = { path = "../config" }
 
-[dependencies.sea-orm-migration]
-version = "^0.12"
-features = ["sqlx-postgres", "sqlx-sqlite", "runtime-actix-rustls"]
+sea-orm-migration = { workspace = true }

--- a/settings/Cargo.toml
+++ b/settings/Cargo.toml
@@ -2,6 +2,7 @@
 name = "settings"
 version = "1.0.1"
 edition = "2021"
+rust-version = "1.91"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,11 +10,11 @@ edition = "2021"
 mock = []
 
 [dependencies]
-serde = { version = "^1", features = ["derive"] }
-serde_json = "^1"
-async-trait = "^0.1"
-async-std = "^1"
-log = "^0.4"
+serde = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+async-std = { workspace = true }
+log = { workspace = true }
 
 config = { path = "../config" }
 error = { path = "../error" }

--- a/settings/src/rule.rs
+++ b/settings/src/rule.rs
@@ -143,7 +143,7 @@ mod test {
 
     #[test]
     fn test_serialize_and_deserialize() {
-        let rule = Rule::new("*@example.com".into());
+        let rule = Rule::new("*@example.com");
         assert_eq!(rule.pattern(), "@example.com");
 
         let serialized = serde_json::to_string(&rule).unwrap();
@@ -154,7 +154,7 @@ mod test {
 
     #[test]
     fn test_starts_with() {
-        let rule = Rule::new("*@example.com".into());
+        let rule = Rule::new("*@example.com");
         assert_eq!(rule.pattern(), "@example.com");
 
         assert!(rule.test_start);
@@ -169,7 +169,7 @@ mod test {
 
     #[test]
     fn test_ends_with() {
-        let rule = Rule::new("test@example.*".into());
+        let rule = Rule::new("test@example.*");
         assert_eq!(rule.pattern(), "test@example.");
 
         assert!(!rule.test_start);
@@ -184,7 +184,7 @@ mod test {
 
     #[test]
     fn test_contains() {
-        let rule = Rule::new("*@example.*".into());
+        let rule = Rule::new("*@example.*");
 
         assert!(!rule.test_start);
         assert!(rule.valid("test@example.com"));
@@ -198,7 +198,7 @@ mod test {
 
     #[test]
     fn test_exact_match() {
-        let rule = Rule::new("else@example.org".into());
+        let rule = Rule::new("else@example.org");
 
         assert!(!rule.test_start);
         assert!(!rule.valid("test@example.com"));

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,6 +2,7 @@
 name = "storage"
 version = "1.2.0"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]
 readme = "README.md"
 license-file = "../LICENSE.md"
@@ -13,15 +14,15 @@ description = "Application storage service that manages files and folders."
 mock = ["context/mock", "entity/mock"]
 
 [dependencies]
-log = "^0.4"
-actix-web = "^4"
-validr = "^0.3"
-serde = "^1"
-serde_json = "^1"
-chrono = "^0.4"
-cached = "^0.43"
-futures = "^0.3"
-num-traits = "0.2"
+log = { workspace = true }
+actix-web = { workspace = true }
+validr = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+cached = { workspace = true }
+futures = { workspace = true }
+num-traits = { workspace = true }
 
 auth = { path = "../auth" }
 context = { path = "../context" }

--- a/storage/src/mock.rs
+++ b/storage/src/mock.rs
@@ -7,8 +7,8 @@ use crate::{
     repository::Repository,
 };
 
-pub async fn create_file<'ctx>(
-    context: &'ctx Context,
+pub async fn create_file(
+    context: &Context,
     user: &users::Model,
     name: &str,
     file_id: Option<Uuid>,

--- a/storage/src/test/create.rs
+++ b/storage/src/test/create.rs
@@ -9,7 +9,7 @@ use crate::{
 fn app_file_vec_to_str_vec(files: &[AppFile]) -> Vec<String> {
     files
         .iter()
-        .map(|f| format!("{} -> {}", f.id, f.file_id.clone().unwrap_or_default()))
+        .map(|f| format!("{} -> {}", f.id, f.file_id.unwrap_or_default()))
         .collect()
 }
 
@@ -95,7 +95,7 @@ async fn get_dir_tree_with_right_ordering() {
     let dir = create_file(&context, &user, "dir", None, Some("dir"))
         .await
         .unwrap();
-    let dir_id = dir.id.clone();
+    let dir_id = dir.id;
     manual.push(dir);
 
     let response = repository.manage(user.id).dir_tree(dir_id).await.unwrap();
@@ -108,19 +108,19 @@ async fn get_dir_tree_with_right_ordering() {
     let dir2 = create_file(&context, &user, "dir", Some(dir_id), Some("dir"))
         .await
         .unwrap();
-    let dir2_id = dir2.id.clone();
+    let dir2_id = dir2.id;
     manual.push(dir2);
 
     let dir3 = create_file(&context, &user, "dir", Some(dir2_id), Some("dir"))
         .await
         .unwrap();
-    let dir3_id = dir3.id.clone();
+    let dir3_id = dir3.id;
     manual.push(dir3);
 
     let dir4 = create_file(&context, &user, "dir", Some(dir3_id), Some("dir"))
         .await
         .unwrap();
-    let dir4_id = dir4.id.clone();
+    let dir4_id = dir4.id;
 
     let _dir5 = create_file(&context, &user, "dir", Some(dir4_id), Some("dir"))
         .await
@@ -154,46 +154,46 @@ async fn get_file_tree_with_right_ordering() {
     let dir = create_file(&context, &user, "dir", None, Some("dir"))
         .await
         .unwrap();
-    let dir_id = dir.id.clone();
+    let dir_id = dir.id;
     manual.push(dir);
 
     let file = create_file(&context, &user, "json1", None, Some("application/json"))
         .await
         .unwrap();
-    let file1_id = file.id.clone();
+    let file1_id = file.id;
     manual.push(file);
 
     let file = create_file(&context, &user, "json2", None, Some("application/json"))
         .await
         .unwrap();
-    let _file2_id = file.id.clone();
+    let _file2_id = file.id;
     manual.push(file);
 
     let dir = create_file(&context, &user, "dir", Some(dir_id), Some("dir"))
         .await
         .unwrap();
-    let dir2_id = dir.id.clone();
+    let dir2_id = dir.id;
     manual.push(dir);
 
     let file = create_file(&context, &user, "json3", None, Some("application/json"))
         .await
         .unwrap();
-    let _file3_id = file.id.clone();
+    let _file3_id = file.id;
     manual.push(file);
 
     let file = create_file(&context, &user, "json4", None, Some("application/json"))
         .await
         .unwrap();
-    let _file4_id = file.id.clone();
+    let _file4_id = file.id;
     manual.push(file);
 
     let dir3 = create_file(&context, &user, "dir", Some(dir2_id), Some("dir"))
         .await
         .unwrap();
-    let dir3_id = dir3.id.clone();
+    let dir3_id = dir3.id;
     manual.push(dir3);
 
-    let ids = manual.iter().map(|f| f.id.clone()).collect::<Vec<_>>();
+    let ids = manual.iter().map(|f| f.id).collect::<Vec<_>>();
 
     let response = repository.manage(user.id).file_tree(dir_id).await.unwrap();
 
@@ -207,9 +207,9 @@ async fn get_file_tree_with_right_ordering() {
         .await
         .unwrap();
 
-    assert_eq!(response.iter().next().unwrap().id, file1_id);
+    assert_eq!(response.first().unwrap().id, file1_id);
 
     let response = repository.manage(user.id).file_tree(dir3_id).await.unwrap();
 
-    assert_eq!(response.iter().next().unwrap().id, dir3_id);
+    assert_eq!(response.first().unwrap().id, dir3_id);
 }

--- a/storage/src/test/delete.rs
+++ b/storage/src/test/delete.rs
@@ -12,7 +12,7 @@ async fn create_recursive_mess_to_test_delete_many() {
     let dir = create_file(&context, &user, "root.dir", None, Some("dir"))
         .await
         .unwrap();
-    let dir_id = dir.id.clone();
+    let dir_id = dir.id;
     manual.push(dir);
 
     let file = create_file(
@@ -35,7 +35,7 @@ async fn create_recursive_mess_to_test_delete_many() {
     )
     .await
     .unwrap();
-    let _file2_id = file.id.clone();
+    let _file2_id = file.id;
     manual.push(file);
 
     let file = create_file(
@@ -63,7 +63,7 @@ async fn create_recursive_mess_to_test_delete_many() {
     let dir = create_file(&context, &user, "root.dir.dir2", Some(dir_id), Some("dir"))
         .await
         .unwrap();
-    let dir2_id = dir.id.clone();
+    let dir2_id = dir.id;
     manual.push(dir);
 
     let dir3 = create_file(
@@ -77,7 +77,7 @@ async fn create_recursive_mess_to_test_delete_many() {
     .unwrap();
     manual.push(dir3);
 
-    let ids = manual.iter().map(|f| f.id.clone()).collect::<Vec<_>>();
+    let ids = manual.iter().map(|f| f.id).collect::<Vec<_>>();
 
     let delete_files = repository
         .manage(user.id)

--- a/storage/src/test/move_many.rs
+++ b/storage/src/test/move_many.rs
@@ -12,7 +12,7 @@ async fn create_recursive_mess_to_test_move_many() {
     let dir = create_file(&context, &user, "root.dir", None, Some("dir"))
         .await
         .unwrap();
-    let dir_id = dir.id.clone();
+    let dir_id = dir.id;
     manual.push(dir);
 
     let file = create_file(
@@ -35,7 +35,7 @@ async fn create_recursive_mess_to_test_move_many() {
     )
     .await
     .unwrap();
-    let _file2_id = file.id.clone();
+    let _file2_id = file.id;
     manual.push(file);
 
     let file = create_file(
@@ -63,7 +63,7 @@ async fn create_recursive_mess_to_test_move_many() {
     let dir = create_file(&context, &user, "root.dir.dir2", Some(dir_id), Some("dir"))
         .await
         .unwrap();
-    let dir2_id = dir.id.clone();
+    let dir2_id = dir.id;
     manual.push(dir);
 
     let dir3 = create_file(
@@ -77,7 +77,7 @@ async fn create_recursive_mess_to_test_move_many() {
     .unwrap();
     manual.push(dir3);
 
-    let ids = manual.iter().map(|f| f.id.clone()).collect::<Vec<_>>();
+    let ids = manual.iter().map(|f| f.id).collect::<Vec<_>>();
 
     let moved = repository
         .manage(user.id)

--- a/storage/src/test/search.rs
+++ b/storage/src/test/search.rs
@@ -28,9 +28,9 @@ async fn create_file_with_tokens() {
     let user = entity::mock::create_user(&context.db, "first@test.com", None).await;
 
     let name = "hello_world.txt";
-    let initial_tokens = cryptfns::tokenizer::into_hashed_tokens(&name).unwrap();
+    let initial_tokens = cryptfns::tokenizer::into_hashed_tokens(name).unwrap();
 
-    let dir = create_file(&context, &user, &name, None, Some("dir"))
+    let dir = create_file(&context, &user, name, None, Some("dir"))
         .await
         .unwrap();
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -2,6 +2,7 @@
 name = "util"
 version = "1.0.1"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]
 readme = "README.md"
 license-file = "../LICENSE.md"
@@ -14,12 +15,12 @@ name = "util"
 path = "src/lib.rs"
 
 [dependencies]
-zxcvbn = "2.2.1"
-google-authenticator = "0.3.0" # new version requires building libs so we'll stay on this one
-bcrypt = "^0.14"
-chrono = "^0.4"
-qstring = "^0.7"
-actix-web = "^4"
-url = "^2"
+zxcvbn = { workspace = true }
+google-authenticator = { workspace = true } # new version requires building libs so we'll stay on this one
+bcrypt = { workspace = true }
+chrono = { workspace = true }
+qstring = { workspace = true }
+actix-web = { workspace = true }
+url = { workspace = true }
 
 error = { path = "../error" }


### PR DESCRIPTION
…endencies

- Complete Actix Web 4.11 upgrade verification
  - Verify FromRequest implementations are compatible
  - Confirm Sea-ORM runtime-actix-rustls compatibility
  - All actix-web related code compiles successfully

- Fix all clippy warnings (102 → 0)
  - Replace .get(0) with .first() in test files
  - Remove needless lifetimes from function signatures
  - Remove unused mut keywords
  - Add is_none() method to OptionLike trait
  - Fix useless conversions and dereferences

- Add rust-version to all Cargo.toml files
  - Set rust-version = 1.91 for all workspace members
  - Ensures consistent Rust version requirements

- Consolidate duplicate dependencies into workspace
  - Add 50+ common dependencies to [workspace.dependencies]
  - Update all 15 workspace members to use workspace = true
  - Single source of truth for dependency versions
  - Easier maintenance and version consistency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes the runtime and unifies dependency management across the workspace.
> 
> - Upgrade Actix ecosystem (`actix-web` 4.11, `actix-cors` 0.7, `actix-multipart` 0.7) and related deps (Tokio 1.48, `url` 2.5.7, etc.); `hoodik` bumped to `1.8.0`
> - Consolidate 50+ shared crates into `[workspace.dependencies]`; switch all member crates to `workspace = true`
> - Add `rust-version = 1.91` to all `Cargo.toml` for consistent toolchain requirements
> - Resolve clippy/test issues: replace `.get(0)` with `.first()`, remove needless lifetimes, drop unused `mut`, adjust Actix test calls (immutable app, header access), add `OptionLike::is_none`, minor string-format cleanups
> - Config tweaks: improve SMTP TLS mode parsing/auto-detect and `default_from` resolution with deprecation warning
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8920c504322910e8b749a6bea69cca7ead7d7fbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->