### PR TITLE
fix: accept AEAD overhead on tar uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "hoodik"
-version = "1.15.0"
+version = "1.15.1"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -12,6 +12,15 @@ pub use filename::IntoFilename;
 /// could dynamically be adjusted for each file.
 pub const MAX_CHUNK_SIZE_BYTES: u64 = 1024 * 1024 * 4;
 
+/// Maximum encrypted body the upload routes accept for one chunk: a full
+/// [`MAX_CHUNK_SIZE_BYTES`] plaintext plus 1 % slack for the AEAD tag and
+/// nonce/header overhead the client appends. Every cipher we ship adds 16
+/// bytes of tag (AEGIS-128L, ChaCha20-Poly1305, Ascon-128a), so 1 % is far
+/// more than the worst case but keeps the per-chunk and tar wire ceilings
+/// in lockstep with one shared constant.
+pub const MAX_CHUNK_PAYLOAD_BYTES: u64 =
+    MAX_CHUNK_SIZE_BYTES + MAX_CHUNK_SIZE_BYTES / 100;
+
 // S3 CopyObject's single-operation limit is 5 GiB. Any chunk larger than that
 // would force the S3 `copy_version` path into a multipart-copy code path we
 // don't have — static-check it now so a future bump of MAX_CHUNK_SIZE_BYTES

--- a/hoodik/Cargo.toml
+++ b/hoodik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoodik"
-version = "1.15.0"
+version = "1.15.1"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]

--- a/hoodik/tests/storage_tar_upload.rs
+++ b/hoodik/tests/storage_tar_upload.rs
@@ -11,6 +11,7 @@ mod helpers;
 use actix_web::{http::StatusCode, test};
 use auth::data::create_user::CreateUser;
 use fs::tar::{tar_header, tar_padding_len, TAR_END_OF_ARCHIVE_LEN};
+use fs::MAX_CHUNK_SIZE_BYTES;
 use hoodik::server;
 use storage::data::app_file::AppFile;
 
@@ -318,6 +319,74 @@ async fn test_upload_tar_not_owned() {
     // existence to unrelated users. Both are 4xx client errors.
     let resp = send_tar!(app, stranger_jwt, file.id, tar_of(&[(0, &chunks[0])]));
     assert!(resp.status().is_client_error(), "got {}", resp.status());
+    context.config.app.cleanup();
+}
+
+/// End-to-end reproduction of the Flutter upload failure observed on
+/// 2026-04-27: any file ≥ 4 MiB bounces off the tar route with
+/// `chunk_size_exceeds_max`. Encrypts a 12 MiB payload through real
+/// AEGIS-128L exactly the way every Hoodik client does, packs the three
+/// 4 MiB-plus-16 B ciphertexts into the same tar shape `transfer::upload_tar`
+/// emits, and POSTs it. The existing tar tests use synthetic chunks of a
+/// few KiB so they never crossed the encrypted-size ceiling that real
+/// uploads sit on.
+#[actix_web::test]
+async fn test_upload_tar_three_chunk_aegis_encrypted_file() {
+    setup!(
+        context,
+        app,
+        jwt,
+        "../data-test-tar-upload-multi-chunk-aegis",
+        "tar-multi-aegis@test.com"
+    );
+
+    let chunk_count = 3usize;
+    let plaintext_chunk_len = MAX_CHUNK_SIZE_BYTES as usize;
+    let key = cryptfns::aegis::generate_key().unwrap();
+
+    let encrypted_chunks: Vec<Vec<u8>> = (0..chunk_count)
+        .map(|i| {
+            let plaintext: Vec<u8> = (0..plaintext_chunk_len)
+                .map(|n| ((i * 17 + n) as u8).wrapping_mul(31))
+                .collect();
+            cryptfns::aegis::encrypt(key.clone(), plaintext).unwrap()
+        })
+        .collect();
+
+    for (i, c) in encrypted_chunks.iter().enumerate() {
+        assert_eq!(
+            c.len(),
+            plaintext_chunk_len + 16,
+            "chunk {i} must carry the AEGIS-128L 16-byte tag",
+        );
+    }
+
+    let file = create_file!(
+        app,
+        jwt,
+        create_file_json(&encrypted_chunks, "multi-chunk-aegis.enc")
+    );
+
+    let resp = send_tar!(app, jwt, file.id, tar_of(&tar_entries(&encrypted_chunks)));
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "tar upload of a 3-chunk AEGIS-encrypted file must succeed; this is \
+         the exact shape the Flutter app produces for any file ≥ 4 MiB",
+    );
+
+    let updated: AppFile = serde_json::from_slice(&test::read_body(resp).await).unwrap();
+    assert_eq!(updated.chunks_stored, Some(chunk_count as i64));
+    assert!(updated.finished_upload_at.is_some());
+
+    let expected: Vec<u8> = encrypted_chunks
+        .iter()
+        .flat_map(|c| c.iter().copied())
+        .collect();
+    assert_eq!(download_bytes!(app, jwt, file.id), expected);
+
+    use fs::prelude::{Fs, FsProviderContract};
+    Fs::new(&context.config).purge_all(&updated).await.unwrap();
     context.config.app.cleanup();
 }
 

--- a/storage/src/routes/upload.rs
+++ b/storage/src/routes/upload.rs
@@ -5,7 +5,7 @@ use auth::data::transfer_claims::StorageClaims;
 use context::Context;
 use entity::Uuid;
 use error::{AppResult, Error};
-use fs::{prelude::*, MAX_CHUNK_SIZE_BYTES};
+use fs::{prelude::*, MAX_CHUNK_PAYLOAD_BYTES};
 use futures::StreamExt;
 
 use crate::{
@@ -15,13 +15,6 @@ use crate::{
         Repository,
     },
 };
-
-/// Per-chunk upload ceiling — one chunk plus the 1% slack the client is
-/// allowed to add on top of [`MAX_CHUNK_SIZE_BYTES`]. Shared between the
-/// chunk-size validator and the manual body collector so a single constant
-/// governs "how much we'll accept for one chunk".
-const MAX_CHUNK_PAYLOAD_BYTES: u64 =
-    MAX_CHUNK_SIZE_BYTES + MAX_CHUNK_SIZE_BYTES / 100;
 
 /// Upload one chunk (per-chunk mode, legacy) or a tar archive of many
 /// chunks (`?format=tar`, bulk mode).

--- a/storage/src/routes/upload_tar.rs
+++ b/storage/src/routes/upload_tar.rs
@@ -24,7 +24,7 @@ use error::{AppResult, Error};
 use fs::{
     prelude::*,
     tar::{parse_next_entry, TarStep},
-    MAX_CHUNK_SIZE_BYTES,
+    MAX_CHUNK_PAYLOAD_BYTES,
 };
 use futures::StreamExt;
 use std::collections::HashSet;
@@ -40,10 +40,10 @@ use crate::{
 
 /// Hard cap on how many bytes we'll hold in the stream-parser buffer before
 /// declaring the request malformed. A compliant request never needs more than
-/// one header (512 B) + one padded chunk payload (≤ MAX_CHUNK_SIZE_BYTES + 512)
+/// one header (512 B) + one padded chunk payload (≤ MAX_CHUNK_PAYLOAD_BYTES + 512)
 /// in flight at once. The generous headroom absorbs header-straddle reads and
 /// any residual bytes behind the current entry without ballooning memory.
-const MAX_BUFFER_BYTES: usize = (MAX_CHUNK_SIZE_BYTES as usize) + 16 * 1024;
+const MAX_BUFFER_BYTES: usize = (MAX_CHUNK_PAYLOAD_BYTES as usize) + 16 * 1024;
 
 /// Handle `POST /api/storage/{file_id}?format=tar`. Dispatched from
 /// [`super::upload::upload`] when the `format` query is set.
@@ -215,7 +215,7 @@ fn validate_chunk_index(chunk_index: i64, target_chunks: i64) -> AppResult<()> {
 }
 
 fn reject_oversize_chunk(len: usize) -> AppResult<()> {
-    if len as u64 > MAX_CHUNK_SIZE_BYTES {
+    if len as u64 > MAX_CHUNK_PAYLOAD_BYTES {
         return Err(Error::as_validation("chunk", "chunk_size_exceeds_max"));
     }
     Ok(())


### PR DESCRIPTION
The tar route validated each entry against raw MAX_CHUNK_SIZE_BYTES (4 MiB exactly), but every encrypted chunk a real client produces is 4 MiB + 16 B — AEGIS-128L, ChaCha20-Poly1305 and Ascon-128a all append a 16-byte authentication tag. Any file >= 4 MiB had its first chunk rejected with `chunk_size_exceeds_max`: Android surfaced the 422 directly, macOS hung at 0 % once background_downloader exhausted its retry budget. The per-chunk endpoint already absorbed this via a private MAX_CHUNK_PAYLOAD_BYTES (4 MiB + 1 % slack); the tar route just didn't share the constant.

Hoist MAX_CHUNK_PAYLOAD_BYTES into \`fs\` as the shared wire-protocol ceiling, route both endpoints through it, and bump the tar parser's in-flight buffer to match. New \`storage_tar_upload\` regression test posts three real AEGIS-128L-encrypted 4 MiB chunks (the exact shape any Hoodik client produces for a 12 MiB file) and asserts a clean 200 plus a byte-identical round-trip — fails on the unfixed code with the same 422 the bug reports surfaced.

Bumps hoodik 1.15.0 -> 1.15.1.

Closes #158