### PR TITLE
fix: selection count in toolbar and 2FA token on password change

### DIFF
--- a/fs/src/providers/s3.rs
+++ b/fs/src/providers/s3.rs
@@ -515,7 +515,7 @@ impl FsProviderContract for S3Provider {
             .collect();
 
         let bucket = self.bucket.clone();
-        futures::stream::iter(src_keys.into_iter().zip(dst_keys.into_iter()))
+        futures::stream::iter(src_keys.into_iter().zip(dst_keys))
             .map(|(src_key, dst_key)| {
                 let bucket = bucket.clone();
                 async move {

--- a/storage/src/repository/manage.rs
+++ b/storage/src/repository/manage.rs
@@ -325,7 +325,7 @@ where
 
         // Sort files by id and then run dedup_by to remove all duplicates,
         // without sorting, this won't remove all duplicates
-        files.sort_by(|a, b| a.id.cmp(&b.id));
+        files.sort_by_key(|a| a.id);
         files.dedup_by(|a, b| a.id == b.id);
 
         let ids: Vec<Uuid> = files.iter().map(|f| f.id).collect();

--- a/web/e2e/change-password.spec.ts
+++ b/web/e2e/change-password.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test'
+import { authenticator } from 'otplib'
+import {
+  randomEmail,
+  randomPassword,
+  createUser,
+  createUserWithTwoFactor,
+  loginAsUser,
+  loginWithTwoFactor,
+  logout,
+} from './helpers/auth'
+
+/**
+ * Walk from the authenticated file browser to the change-password screen
+ * via the in-app sidebar + "My account" link. A full `page.goto` would
+ * reload the SPA and drop the in-memory keypair, bouncing the user back
+ * to /auth/login.
+ */
+async function openChangePasswordViaSidebar(page: import('@playwright/test').Page) {
+  await page.locator('aside').getByText('Account', { exact: true }).first().click()
+  await page.waitForURL(/\/account(\/|$|\?)/)
+  await page.getByRole('link', { name: 'Change', exact: true }).click()
+  await page.waitForURL(/\/account\/change-password/)
+}
+
+test.describe('Change password', () => {
+  test('with no TFA, change password via current password succeeds', async ({ page }) => {
+    const email = randomEmail()
+    const password = randomPassword()
+    await createUser(page, email, password)
+
+    await openChangePasswordViaSidebar(page)
+    await page.locator('#current_password').fill(password)
+
+    const newPassword = randomPassword()
+    await page.locator('#password').fill(newPassword)
+
+    const response = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/auth/account/change-password') &&
+        res.request().method() === 'POST'
+    )
+    await page.getByRole('button', { name: 'Change password' }).click()
+    expect((await response).status()).toBe(204)
+
+    await logout(page)
+    await loginAsUser(page, email, newPassword)
+    await expect(page).toHaveURL(/\/$/)
+  })
+
+  // Regression test for https://github.com/hudikhq/hoodik/issues/164
+  test('with TFA enabled, change password via private key + OTP succeeds', async ({ page }) => {
+    const email = randomEmail()
+    const password = randomPassword()
+    const { privateKey, secret } = await createUserWithTwoFactor(page, email, password)
+
+    await openChangePasswordViaSidebar(page)
+    await page.locator('#use_private_key').check()
+    await page.locator('#private_key').fill(privateKey)
+    await page.locator('#token').fill(authenticator.generate(secret))
+
+    const newPassword = randomPassword()
+    await page.locator('#password').fill(newPassword)
+
+    const response = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/auth/account/change-password') &&
+        res.request().method() === 'POST'
+    )
+    await page.getByRole('button', { name: 'Change password' }).click()
+
+    // The bug in #164 manifests as a 401 with body `invalid_otp_token`
+    // because the frontend silently dropped the token before sending.
+    // After the fix the backend returns 204.
+    expect((await response).status()).toBe(204)
+
+    await logout(page)
+    await loginWithTwoFactor(page, email, newPassword, secret)
+    await expect(page).toHaveURL(/\/$/)
+  })
+})

--- a/web/e2e/files.spec.ts
+++ b/web/e2e/files.spec.ts
@@ -91,6 +91,34 @@ test.describe('Rename', () => {
   })
 })
 
+test.describe('Selection counter', () => {
+  test('shows the count of selected items in the toolbar and updates as selection changes', async ({ page }) => {
+    await setup(page)
+
+    for (const name of ['Folder_A', 'Folder_B']) {
+      await page.locator('[name="create-dir"]').click()
+      await page.locator('#name').fill(name)
+      await page.getByRole('button', { name: 'Create', exact: true }).click()
+      await expect(page.getByTestId(`file-row-${name}`)).toBeVisible()
+    }
+
+    const counter = page.getByTestId('files-selected-count')
+    await expect(counter).toHaveCount(0)
+
+    await page.getByTestId('file-row-Folder_A').locator('input[type="checkbox"]').check()
+    await expect(counter).toHaveText(/^1 selected$/)
+
+    await page.getByTestId('file-row-Folder_B').locator('input[type="checkbox"]').check()
+    await expect(counter).toHaveText(/^2 selected$/)
+
+    await page.getByTestId('file-row-Folder_A').locator('input[type="checkbox"]').uncheck()
+    await expect(counter).toHaveText(/^1 selected$/)
+
+    await page.getByTestId('file-row-Folder_B').locator('input[type="checkbox"]').uncheck()
+    await expect(counter).toHaveCount(0)
+  })
+})
+
 test.describe('Delete', () => {
   test('can delete a file', async ({ page }) => {
     await setup(page)

--- a/web/services/account.ts
+++ b/web/services/account.ts
@@ -24,6 +24,10 @@ export async function changePassword(payload: UnsecureChangePassword): Promise<v
     email: payload.email
   }
 
+  if (payload.token) {
+    data.token = payload.token
+  }
+
   if (payload.current_password) {
     data.current_password = payload.current_password
   } else {

--- a/web/src/views/files/index-view/TableFiles.vue
+++ b/web/src/views/files/index-view/TableFiles.vue
@@ -175,6 +175,12 @@ const sizes = {
     class="w-full p-2 mb-2 flex rounded-t-md bg-brownish-100 dark:bg-brownish-900 gap-4"
     v-if="showActions"
   >
+    <span
+      v-if="checkedRows.length"
+      data-testid="files-selected-count"
+      class="self-center text-sm text-brownish-700 dark:text-brownish-200"
+    >{{ checkedRows.length }} selected</span>
+
     <BaseButton
       title="Delete"
       :iconSize="20"


### PR DESCRIPTION
## Summary

Two small fixes bundled together, both shipping with their own E2E regression coverage.

### #163 — Show selection count in the files toolbar

Adds a "N selected" label at the start of the file-browser toolbar so users can keep track of how many files/folders are in the current multi-selection. It appears as soon as a checkbox is checked and disappears when the last selection is cleared.

### #164 — Cannot change password with TFA enabled

`web/services/account.ts::changePassword()` constructs the request body but never copied `payload.token` over to `data.token`. The form prompts for an OTP, the user enters it, but the request always hit the backend with `token: None`. `auth::contracts::account::change_password` then ran `verify_tfa(None)`, which returns `false` for any TFA-enabled account → `401 invalid_otp_token`. This affected both the private-key and current-password paths (the issue happens to be reported on the private-key one). The fix is a three-line addition that forwards the token when present.

The backend logic was already correct — see `auth/src/contracts/account.rs:27` and `util/src/validation.rs:31`. No backend change needed.

## Test plan

- [x] `just clippy`
- [x] `just lint-web`
- [x] `just check-types`
- [x] `just test-web` (106 tests)
- [x] `just e2e` — full suite, 46/46 passing including the two new specs
  - `web/e2e/change-password.spec.ts` — covers both no-TFA and TFA private-key paths (the TFA case fails on master with HTTP 401 before the fix; passes after)
  - `web/e2e/files.spec.ts` — new "Selection counter" case asserts the toolbar updates as boxes are checked/unchecked
- [x] Visual check in a logged-in browser — counter renders centered with the action buttons in both light and dark mode