### PR TITLE
chore: bump hoodik to 1.15.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "hoodik"
-version = "1.15.2"
+version = "1.15.3"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/hoodik/Cargo.toml
+++ b/hoodik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoodik"
-version = "1.15.2"
+version = "1.15.3"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]


### PR DESCRIPTION
Patch version bump. On merge, `release.yml` (watches `hoodik/Cargo.toml`) creates `v1.15.3` and `pack-and-publish.yml` builds the release artifacts.

Picks up the changes that landed in #166:
- Selection count in the file-browser toolbar (#163)
- Change-password 2FA token forwarding fix (#164)

## Test plan
- [x] `just ci-test` — full pipeline green locally (clippy + rust unit/integration + wasm + test-web + build-web + e2e 46/46)
- [x] `version-verify.yml` will confirm `v1.15.3` tag does not yet exist