### PR TITLE
feat: link to the native apps from the web UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "hoodik"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/hoodik/Cargo.toml
+++ b/hoodik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoodik"
-version = "1.15.3"
+version = "1.15.4"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]

--- a/web/src/components/ui/AsideMenuItem.vue
+++ b/web/src/components/ui/AsideMenuItem.vue
@@ -53,6 +53,7 @@ const menuClick = (event: Event) => {
       :to="item.to ?? null"
       :href="item.href ?? null"
       :target="item.target ?? null"
+      :rel="item.rel ?? null"
       class="flex cursor-pointer"
       :class="componentClass"
       @click="menuClick"

--- a/web/src/components/ui/AsideMenuLayer.vue
+++ b/web/src/components/ui/AsideMenuLayer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { mdiClose, mdiLogout } from '@mdi/js'
+import { mdiClose, mdiLogout, mdiCellphoneLink } from '@mdi/js'
 import { computed, ref, watch } from 'vue'
 import { store as style } from '!/style'
 import { store as login } from '!/auth/login'
@@ -63,6 +63,14 @@ const lockAccountItem = computed(() => ({
   isLogout: true
 }))
 
+const getAppsItem = computed(() => ({
+  label: 'Get the apps',
+  icon: mdiCellphoneLink,
+  href: 'https://hoodik.io/apps?utm_source=hoodik-server',
+  target: '_blank',
+  rel: 'noopener noreferrer'
+}))
+
 const name = computed(() => import.meta.env.APP_NAME || 'Hoodik')
 const version = computed(() => import.meta.env.APP_VERSION || '')
 
@@ -119,6 +127,7 @@ const logoutAction = async () => {
       </div>
 
       <ul>
+        <AsideMenuItem :item="getAppsItem" />
         <StatsLi />
         <AsideMenuItem :item="lockAccountItem" @menu-click="logoutAction" />
       </ul>


### PR DESCRIPTION
Adds a small "Get the apps" link in the authenticated sidebar footer (alongside storage stats and logout), so people already running a Hoodik server discover the native iOS / Android / macOS clients.

## Changes
- `AsideMenuLayer.vue`: a `getAppsItem` rendered via the existing `AsideMenuItem` (modeled on the logout item), added to the sidebar footer list.
- `AsideMenuItem.vue`: passthrough `:rel` binding so the external link carries `rel="noopener noreferrer"`.

## Details
- Links to `https://hoodik.io/apps?utm_source=hoodik-server`, opening in a new tab.
- The target page is reachable only from this link or a direct URL (it isn't in the site navigation and is not indexed), so its traffic measures click-throughs from running servers. The `utm_source` keeps that attribution reliable even when referrers are stripped.