### PR TITLE
fix: admin available space respects the instance quota

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "hoodik"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/admin/src/repository/files.rs
+++ b/admin/src/repository/files.rs
@@ -98,8 +98,15 @@ where
             .rows_affected)
     }
 
-    /// Get the available space on the storage provider
-    pub(crate) async fn available_space(&self) -> AppResult<u64> {
+    /// Get the available space on the storage provider. When an instance-wide
+    /// quota is configured, that quota is the real ceiling — an S3-backed
+    /// provider otherwise reports `u64::MAX` (no such thing as "disk free space"
+    /// on object storage), which is meaningless to show an operator.
+    pub(crate) async fn available_space(&self, used: i64) -> AppResult<u64> {
+        if let Some(quota) = self.repository.context().config.app.storage_instance_quota_bytes {
+            return Ok(quota.saturating_sub(used.max(0) as u64));
+        }
+
         let fs = Fs::new(&self.repository.context().config);
         fs.available_space().await
     }

--- a/admin/src/routes/files/index.rs
+++ b/admin/src/routes/files/index.rs
@@ -18,7 +18,8 @@ pub(crate) async fn index(staff: Staff, context: web::Data<Context>) -> AppResul
     let repository = Repository::new(&context, &context.db);
 
     let stats = repository.files().stats().await?;
-    let available_space = repository.files().available_space().await?;
+    let used: i64 = stats.iter().map(|s| s.size).sum();
+    let available_space = repository.files().available_space(used).await?;
 
     Ok(HttpResponse::Ok().json(Response {
         available_space,

--- a/hoodik/Cargo.toml
+++ b/hoodik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoodik"
-version = "1.16.0"
+version = "1.16.1"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]

--- a/hoodik/tests/storage_instance_quota.rs
+++ b/hoodik/tests/storage_instance_quota.rs
@@ -171,6 +171,29 @@ async fn instance_quota_concurrent_creates_admit_exactly_one() {
 }
 
 #[actix_web::test]
+async fn instance_quota_shapes_admin_available_space() {
+    let mut context = context::Context::mock_sqlite().await;
+    context.config.app.storage_instance_quota_bytes = Some(10240);
+    let app = test::init_service(server::app(context.clone())).await;
+    // The first registered user is the admin (auth/contracts/register.rs).
+    register!(app, jwt, "alice@example.com");
+
+    let create = post_create!(app, jwt, sized_create("hash-admin-space", &[4096]));
+    assert_eq!(create.status(), StatusCode::OK);
+
+    let req = test::TestRequest::get()
+        .uri("/api/admin/files")
+        .cookie(jwt.clone())
+        .to_request();
+    let body: Value = test::call_and_read_body_json(&app, req).await;
+    assert_eq!(
+        body["available_space"], 6144,
+        "available space must be the instance ceiling minus what's actually used, \
+         not the storage provider's raw (and for S3, meaningless) capacity"
+    );
+}
+
+#[actix_web::test]
 async fn instance_quota_rejects_tar_pre_read() {
     let mut context = context::Context::mock_with_data_dir(Some(
         "../data-test-instq-preread".to_string(),


### PR DESCRIPTION
## Summary
- `S3Provider::available_space()` returns `u64::MAX` (object storage has no "disk free space" concept). The admin Storage Overview card ran that straight through `formatSize`, showing a nonsensical ~17.18 exabyte figure on any S3-backed deployment.
- When `STORAGE_INSTANCE_QUOTA_BYTES` is configured, that quota is the actual ceiling, so `available_space` now returns quota minus real usage instead. Deployments without an instance quota keep the existing raw-disk behavior unchanged.
- Bumps the crate to 1.16.1.

## Test plan
- [x] `cargo test -p hoodik --test storage_instance_quota` (5/5 passing, including the new `instance_quota_shapes_admin_available_space` regression case)
- [x] `cargo clippy -p admin -p hoodik --lib -- -D warnings` clean