### PR TITLE
docs: list Bacon as the dev server prerequisite

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,7 @@
 - Rust (stable, >= 1.91) via [rustup](https://rustup.rs/)
 - Node.js 22 (see [.nvmrc](.nvmrc)) and [Yarn](https://yarnpkg.com/) (`npm install -g yarn`)
 - [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
-- [cargo-watch](https://crates.io/crates/cargo-watch) (`cargo install cargo-watch`)
+- [bacon](https://crates.io/crates/bacon) (`cargo install --locked bacon`)
 - [just](https://just.systems/) (`cargo install just`)
 - Docker (for MinIO / PostgreSQL dev services)
 
@@ -22,7 +22,7 @@ This installs JS dependencies, copies `.env.example` to `.env`, builds the WASM 
 ```shell
 just dev          # frontend (Vite :5173) + backend (:5443) with hot-reload
 just dev-web      # Vite dev server only
-just dev-api      # Rust backend only (cargo-watch)
+just dev-api      # Rust backend only (bacon)
 ```
 
 `just dev` builds the WASM crate, then starts both the Vite dev server and the Rust backend with auto-reload. Files are stored on the local filesystem in `DATA_DIR` by default.

--- a/Justfile
+++ b/Justfile
@@ -4,7 +4,7 @@ default:
 
 # ── Development ───────────────────────────────────────────────────────────────
 
-# Run frontend (Vite) and backend (cargo-watch) together
+# Run frontend (Vite) and backend (bacon) together
 # Rebuilds WASM first so the browser always gets the latest crypto code.
 # Kills any stale hoodik binaries left over from previous sessions before starting.
 dev: wasm build-editor


### PR DESCRIPTION
## Summary

  - replace the stale `cargo-watch` prerequisite with `bacon`
  - document `cargo install --locked bacon` to avoid dependency resolution issues
  - update the `just dev-api` description and stale Justfile comment

## Why

`just dev` and `just dev-api` currently run `bacon run-long`, so a fresh setup fails with `bacon: command not found` if users follow the existing docs.