### PR TITLE
fix: honor SSL_DISABLED before loading TLS files

### DIFF
--- a/hoodik/src/server/mod.rs
+++ b/hoodik/src/server/mod.rs
@@ -97,7 +97,11 @@ pub async fn engage(context: Context) -> AppResult<()> {
     let disabled = context.config.ssl.disabled;
     let app_url = context.config.get_app_url();
     let workers = context.config.app.workers;
-    let config = context.config.ssl.build_rustls_config(vec![app_url])?;
+    let rustls_config = if disabled {
+        None
+    } else {
+        Some(context.config.ssl.build_rustls_config(vec![app_url])?)
+    };
 
     let mut server = HttpServer::new(move || {
         // Health probes hit /api/liveness every few seconds; logging them buries
@@ -117,10 +121,11 @@ pub async fn engage(context: Context) -> AppResult<()> {
     if disabled {
         server.bind(&bind_address)?.run().await.map_err(Error::from)
     } else {
+        let config = rustls_config.expect("rustls config must be built when SSL is enabled");
         server
-        .bind_rustls(&bind_address, config)?
-        .run()
-        .await
-        .map_err(Error::from)
+            .bind_rustls(&bind_address, config)?
+            .run()
+            .await
+            .map_err(Error::from)
     }
 }


### PR DESCRIPTION
## Summary

  - skip Rustls config construction when `SSL_DISABLED=true`
  - avoid reading or generating TLS cert/key files in disabled-SSL mode
  - keep existing HTTPS behavior unchanged when SSL is enabled

  ## Why

The server printed `SSL is disabled` but still built the Rustls config before branching on the flag. That caused local dev runs with `SSL_DISABLED=true` to fail if TLS files were missing or pointed at unwritable paths.