### PR TITLE
fix: CORS preflight failure for account settings PATCH request

### DIFF
--- a/hoodik/src/server/cors.rs
+++ b/hoodik/src/server/cors.rs
@@ -17,7 +17,7 @@ pub fn setup() -> Cors {
         .allow_any_origin()
         .supports_credentials()
         .allowed_origin_fn(move |_, _| true)
-        .allowed_methods(vec!["GET", "POST", "PUT", "DELETE"])
+        .allowed_methods(vec!["GET", "POST", "PUT", "PATCH", "DELETE"])
         .expose_headers(expose)
         .allowed_headers(vec![
             http::header::CONTENT_TYPE,

--- a/hoodik/tests/cors.rs
+++ b/hoodik/tests/cors.rs
@@ -1,0 +1,26 @@
+use actix_web::{http, test};
+use hoodik::server;
+
+#[actix_web::test]
+async fn cors_preflight_allows_patch_requests() {
+    let context = context::Context::mock_sqlite().await;
+    let app = test::init_service(server::app(context)).await;
+
+    let req = test::TestRequest::default()
+        .method(http::Method::OPTIONS)
+        .uri("/api/users/me")
+        .insert_header((http::header::ORIGIN, "https://app.example.test"))
+        .insert_header((http::header::ACCESS_CONTROL_REQUEST_METHOD, "PATCH"))
+        .insert_header((http::header::ACCESS_CONTROL_REQUEST_HEADERS, "content-type"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert!(resp.status().is_success());
+    let methods = resp
+        .headers()
+        .get(http::header::ACCESS_CONTROL_ALLOW_METHODS)
+        .expect("preflight response should include allowed methods")
+        .to_str()
+        .expect("allowed methods should be valid header text");
+    assert!(methods.contains("PATCH"));
+}


### PR DESCRIPTION
Fixes a CORS issue where the account setting “Email me when someone shares a file with me” could fail with a 400 response in deployed setups.

The frontend updates this setting through `PATCH /api/users/me`, but the server CORS configuration only allowed `GET`, `POST`, `PUT`, and `DELETE`.
In cross-origin deployments the browser sends an OPTIONS preflight before the PATCH request, and that preflight was not allowed.

This adds `PATCH` to the allowed CORS methods and adds a regression test covering the preflight request for `/api/users/me`