### PR TITLE
Fix password validation mismatch between registration UI and backend

### DIFF
--- a/web/src/components/account/ChangePasswordForm.vue
+++ b/web/src/components/account/ChangePasswordForm.vue
@@ -6,7 +6,7 @@ import * as yup from 'yup'
 import { changePassword } from '!/account'
 import type { ErrorResponse } from '!/api'
 import * as logger from '!/logger'
-import { zxcvbn } from '@zxcvbn-ts/core'
+import { isStrongPassword } from '@/utils/password'
 import { notify } from '@kyvg/vue3-notification'
 
 const props = defineProps<{
@@ -36,7 +36,7 @@ const init = () => {
         .test(
           'weak-password',
           'New password used is too weak',
-          (value: string) => zxcvbn(value).score > 3
+          (value: string | undefined) => isStrongPassword(value)
         )
     }),
     onSubmit: async (values: UnsecureChangePassword, ctx: any) => {

--- a/web/src/utils/password.ts
+++ b/web/src/utils/password.ts
@@ -1,0 +1,5 @@
+import { zxcvbn } from '@zxcvbn-ts/core'
+
+export function isStrongPassword(password: string | undefined): boolean {
+  return !!password && zxcvbn(password).score > 3
+}

--- a/web/src/views/auth/register/IndexView.vue
+++ b/web/src/views/auth/register/IndexView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { AppForm, AppField, AppButton } from '@/components/form'
 import * as yup from 'yup'
-import { zxcvbn } from '@zxcvbn-ts/core'
+import { isStrongPassword } from '@/utils/password'
 import { store } from '!/auth/register'
 import { useRoute, useRouter } from 'vue-router'
 import { computed, ref } from 'vue'
@@ -46,7 +46,7 @@ const init = () => {
         .test(
           'weak-password',
           'Password used is too weak',
-          (value: string) => zxcvbn(value).score >= 3
+          (value: string | undefined) => isStrongPassword(value)
         ),
       confirm_password: yup
         .string()

--- a/web/tests/password.test.ts
+++ b/web/tests/password.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+
+import { isStrongPassword } from '../src/utils/password'
+
+describe('password validation', () => {
+  it('requires zxcvbn score above 3 to match backend validation', () => {
+    expect(isStrongPassword('weak-pass')).toBe(false)
+    expect(isStrongPassword('strong-password-123!')).toBe(true)
+  })
+})


### PR DESCRIPTION
This fixes a password validation mismatch where the registration form could allow a password that the backend later rejected with `weak_password`.

The backend password validator requires a zxcvbn score above 3. The change-password form already used that same rule, but the registration form allowed score 3 passwords as valid. That meant a user could get through the first registration step in the browser, continue through the flow, and only then hit a backend validation error.

The frontend now has one shared password-strength helper using the backend-equivalent rule:

`zxcvbn(password).score > 3`

Both registration and change-password use that helper, so the two frontend flows stay consistent with each other and with the backend.

I also added a focused unit test that checks a score-3 password is rejected while a stronger password is accepted.

Verified with:

```bash
yarn workspace @hoodik/web test:unit web/tests/password.test.ts
yarn workspace @hoodik/web type-check
```