### PR TITLE
ci: pin Rust toolchain, fix clippy drift, retry flaky e2e

### DIFF
--- a/config/src/app.rs
+++ b/config/src/app.rs
@@ -177,7 +177,7 @@ impl AppConfig {
         let data_dir = data_dir.unwrap_or_else(|| self.data_dir.clone());
 
         let data_dir = absolute_path(&data_dir)
-            .unwrap_or_else(|| panic!("Couldn't get absolute path for '{}'", &data_dir));
+            .unwrap_or_else(|| panic!("Couldn't get absolute path for '{}'", data_dir));
 
         match DirBuilder::new().recursive(true).create(&data_dir) {
             Ok(_) => (),
@@ -202,7 +202,7 @@ impl AppConfig {
         } else {
             std::env::set_var(
                 "DATABASE_URL",
-                format!("sqlite:{}/sqlite.db?mode=rwc", &self.data_dir),
+                format!("sqlite:{}/sqlite.db?mode=rwc", self.data_dir),
             );
         }
 

--- a/config/src/auth.rs
+++ b/config/src/auth.rs
@@ -152,12 +152,12 @@ fn get_cookie_domain(vars: &mut Vars, app_url: &Url) -> String {
         .map(|x| x.to_string())
         .unwrap_or_else(|| "localhost".to_string());
 
-    let maybe_url = Url::parse(format!("https://{}", &cookie_domain).as_str());
+    let maybe_url = Url::parse(format!("https://{}", cookie_domain).as_str());
 
     if maybe_url.is_err() {
         log::warn!(
                 "'{}' couldn't be parsed into a cookie domain, will use app_url host '{}' for cookie domain",
-                &cookie_domain,
+                cookie_domain,
                 app_url_domain
             );
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,9 @@
+# Pin the Rust toolchain so clippy/rustc are reproducible across local and CI.
+# CI has no explicit toolchain step and was using the runner's rolling default,
+# so a new stable could start flagging pre-existing code (e.g. clippy's
+# redundant-reference lint) and red the pipeline on unrelated PRs. Bump this
+# deliberately, fixing any new lints in the same change.
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]
+targets = ["wasm32-unknown-unknown"]

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -26,7 +26,12 @@ export default defineConfig({
   fullyParallel: false,
   workers: 1,
   timeout: 60_000,
-  retries: 0,
+  // Retry on CI only. Browser-driven flows have inherent timing flakiness
+  // (a move request or confirm dialog occasionally lands a beat late); with
+  // retries: 0 a single transient miss reds an hour-long pipeline. Locally we
+  // keep 0 for fast, honest feedback. A test that passes on retry is reported
+  // as "flaky", so recurring offenders stay visible.
+  retries: process.env.CI ? 2 : 0,
   reporter: [['html', { open: 'never' }], ['list']],
   use: {
     baseURL,


### PR DESCRIPTION
## Why

Several open PRs (#176, #178, #180) are failing CI **not because of their own code** — they trip on two pre-existing pipeline problems:

1. **Clippy toolchain drift.** CI has no toolchain step, so it uses the runner's rolling default stable. A newer clippy started flagging `format!("{}", &x)`-style redundant references in `config/` — code none of those PRs touch. `just clippy` runs first, so it sinks the whole run before the PR's own changes are even tested.
2. **E2E flakiness.** `playwright.config.ts` had `retries: 0`, so a single transient browser-timing miss (a move request or confirm dialog landing a beat late in `shares-editable-folders.spec.ts`) reds an hour-long pipeline.

Neither is caused by the contributor's changes; a docs-only PR (#176) hit both.

## What

- **Pin the toolchain** — `rust-toolchain.toml` at `1.95.0` (with `clippy`, `rustfmt`, and the `wasm32-unknown-unknown` target). rustc/clippy are now reproducible between local and CI and won't silently drift; bump deliberately.
- **Drop the four redundant references** clippy flagged in `config/src/app.rs` and `config/src/auth.rs`, so the code stays clean when the pin is bumped.
- **Retry e2e on CI** (`retries: 2` on CI, `0` locally). A test that passes on retry is reported as flaky, so recurring offenders stay visible.

Once this lands, the pending fixes rebase onto it and go green on their own merits.