### PR TITLE
CI: parallel jobs and superseded-run cancellation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,76 +5,148 @@ on:
     branches:
       - master
 
+# A superseded run has no audience — kill it the moment a newer push
+# arrives instead of letting two full pipelines queue behind each other.
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: lint
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: curl libpq-dev clang llvm pkg-config nettle-dev libc6-dev
+          version: 1.0
+      - uses: extractions/setup-just@v2
+      - name: Clippy
+        run: just clippy
 
+  rust-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - name: Free disk space
-        # The workspace builds a large debug target/ across the integration test
-        # binaries; with the restored rust-cache, Node deps, and Playwright on
-        # top it overran the runner's ~14 GB (ENOSPC during yarn install). Drop
-        # preinstalled SDKs the job never touches (Android alone is ~9 GB).
+        # The workspace's debug target/ plus the restored rust-cache overran
+        # the runner's ~14 GB before the job split; the SDK purge stays as
+        # cheap insurance (Android alone is ~9 GB).
         run: |
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
             /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
           df -h /
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-unit
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: curl libpq-dev clang llvm pkg-config nettle-dev libc6-dev
+          version: 1.0
+      - uses: extractions/setup-just@v2
+      - name: Rust unit tests
+        run: just test-rust-unit
 
+  rust-integration:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          df -h /
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-integration-${{ matrix.shard }}
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: curl libpq-dev clang llvm pkg-config nettle-dev libc6-dev
+          version: 1.0
+      - name: Integration tests (shard ${{ matrix.shard }})
+        # Every file under hoodik/tests/ is a test target; round-robin them
+        # across the shards by index. Deriving the list from the directory
+        # means a newly added suite always runs — there is no hand-kept list
+        # to forget to update. Helper modules compile to zero-test targets,
+        # which is exactly what clippy already proves they can do.
+        run: |
+          args=""
+          i=0
+          for suite in $(ls hoodik/tests/*.rs | xargs -n1 basename | sed 's/\.rs$//' | sort); do
+            if [ $((i % 3)) -eq ${{ matrix.shard }} ]; then
+              args="$args --test $suite"
+            fi
+            i=$((i + 1))
+          done
+          echo "Running:$args"
+          cargo test $args -- --nocapture
+
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           # Pinned via .nvmrc — transfer WASM uses externref / reference-types
           # which older Node WebAssembly engines reject at parse time.
           node-version-file: '.nvmrc'
-
+          cache: yarn
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: web-wasm
+      - uses: extractions/setup-just@v2
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install yarn and dependencies
+        run: npm install -g yarn && yarn install
+      - name: Build WASM crates
+        run: just wasm
+      - name: Frontend unit tests
+        run: just test-web
+      - name: Build web
+        run: just build-web
 
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          df -h /
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # The release server build lives only in this job's cache line, so
+          # a warm run pays Playwright, not a full optimized recompile.
+          shared-key: e2e-release
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: curl libpq-dev clang llvm pkg-config nettle-dev libc6-dev
           version: 1.0
-
       - uses: extractions/setup-just@v2
-
-      - name: Print versions
-        run: |
-          rustc --version
-          cargo clippy --version
-          just --version
-
-      - name: Clippy
-        run: just clippy
-
-      - name: Rust unit tests
-        run: just test-rust-unit
-
-      - name: Rust integration tests
-        run: just test-rust-integration
-
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
       - name: Install yarn and dependencies
         run: npm install -g yarn && yarn install
-
       - name: Install Playwright browsers
         run: cd web && npx playwright install --with-deps chromium
-
-      - name: Build WASM crates
-        run: just wasm
-
-      - name: Frontend unit tests
-        run: just test-web
-
-      - name: Build web
-        run: just build-web
-
       - name: E2E tests
         run: just e2e
-
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,6 +157,24 @@ jobs:
             web/test-results/
           retention-days: 14
 
+  # Branch protection requires a single check named "test". This gate is
+  # that name: it succeeds only when every job above did, so the required
+  # check stays stable no matter how the jobs behind it are re-arranged.
+  test:
+    runs-on: ubuntu-latest
+    needs: [lint, rust-unit, rust-integration, web, e2e]
+    if: always()
+    steps:
+      - name: Verify all jobs passed
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "Job results: $results"
+          for result in $results; do
+            if [ "$result" != "success" ]; then
+              exit 1
+            fi
+          done
+
   s3-aws-integration:
     runs-on: ubuntu-latest
     # GitHub secrets aren't available to forked-PR workflows — skip cleanly

--- a/web/e2e/shares-edge-cases.spec.ts
+++ b/web/e2e/shares-edge-cases.spec.ts
@@ -68,11 +68,14 @@ test.describe('Sharing edge cases', () => {
 
     await openSharedWithMe(page)
     // The intercept corrupts items[0] of every /api/shares/mine call.
-    // The endpoint orders by `shared_at DESC, created_at DESC`, so the
-    // most recent share (test-image2.png) lands at items[0]; the older
-    // test-image.png decrypts cleanly and renders with its plaintext
-    // name.
-    const goodRow = page.getByTestId('file-row-test-image.png')
+    // Which share sits at items[0] depends on `shared_at DESC` — and both
+    // shares can land within the same second, making the tie-break (and
+    // therefore the corrupted row) environment-dependent. The assertions
+    // are order-agnostic: whichever row survived renders its plaintext
+    // name, the other falls back to its file id below.
+    const goodRow = page
+      .getByTestId('file-row-test-image.png')
+      .or(page.getByTestId('file-row-test-image2.png'))
     await expect(goodRow).toBeVisible({ timeout: 15_000 })
 
     // The corrupted row renders the file id as a name fallback (the


### PR DESCRIPTION
The test workflow ran everything in one serial job: on any Cargo.lock change the cache went cold and a full debug build + 31-minute serial integration march + from-scratch release build inside the E2E step added up to a ~70-minute wall — and pushing again queued a second full pipeline behind the first.

## What changes
- **Superseded runs cancel immediately** when a newer push arrives (`concurrency` + `cancel-in-progress`).
- **Parallel jobs**: clippy, Rust unit tests, integration tests, the web suite (WASM + vitest + build) and E2E each run as their own job. Wall time becomes the slowest job (E2E), not the sum of all steps.
- **Integration tests shard 3-ways**, round-robin over the files in `hoodik/tests/` — the list is derived from the directory at run time, so a newly added suite always runs; there is no hand-maintained list to forget. Helper modules compile to zero-test targets, which clippy already proves they can.
- **Per-job cache lines** (`rust-cache` shared keys): the E2E job's release build persists between runs instead of being evicted behind the debug artifacts; lint/unit/integration/web each warm their own line. Yarn cache added to the node jobs.

## What does not change
Same commands, same suites, same configurations, same `--nocapture` output, same Playwright report upload on failure, same S3 integration job and forked-PR guard. Nothing about the testing surface is removed or weakened — only when and where it runs.

## Expected effect
- Warm cache: wall time drops from ~45–70 min to roughly the E2E job (~15–20 min), with everything else finishing earlier in parallel.
- Cold cache (lockfile changes): parallel cold builds instead of serial ones — bounded by the E2E job's cold release build rather than the sum of every step.
- Rapid iteration on a PR no longer stacks runs.

First run on this PR is all-cold (new cache keys), so judge timings from the second run onward.