### PR TITLE
Add autocomplete attributes to auth form fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "hoodik"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/hoodik/Cargo.toml
+++ b/hoodik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoodik"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -66,6 +66,24 @@ test.describe('Login', () => {
   })
 })
 
+test.describe('Password manager hints', () => {
+  test('login fields are annotated with autocomplete', async ({ page }) => {
+    await page.goto('/auth/login')
+
+    await expect(page.locator('#email')).toHaveAttribute('autocomplete', 'username')
+    await expect(page.locator('#password')).toHaveAttribute('autocomplete', 'current-password')
+    await expect(page.locator('#token')).toHaveAttribute('autocomplete', 'one-time-code')
+  })
+
+  test('registration fields are annotated with autocomplete', async ({ page }) => {
+    await page.goto('/auth/register')
+
+    await expect(page.locator('#email')).toHaveAttribute('autocomplete', 'username')
+    await expect(page.locator('#password')).toHaveAttribute('autocomplete', 'new-password')
+    await expect(page.locator('#confirm_password')).toHaveAttribute('autocomplete', 'new-password')
+  })
+})
+
 test.describe('Logout', () => {
   test('logout redirects to login page', async ({ page }) => {
     const email = randomEmail()

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -73,6 +73,8 @@ test.describe('Password manager hints', () => {
     await expect(page.locator('#email')).toHaveAttribute('autocomplete', 'username')
     await expect(page.locator('#password')).toHaveAttribute('autocomplete', 'current-password')
     await expect(page.locator('#token')).toHaveAttribute('autocomplete', 'one-time-code')
+    await expect(page.locator('#token')).toHaveAttribute('inputmode', 'numeric')
+    await expect(page.locator('#token')).toHaveAttribute('type', 'text')
   })
 
   test('registration fields are annotated with autocomplete', async ({ page }) => {

--- a/web/src/components/account/ChangePasswordForm.vue
+++ b/web/src/components/account/ChangePasswordForm.vue
@@ -103,6 +103,7 @@ init()
       :label="$t('account.changePassword.emailLabel')"
       name="email"
       placeholder="your@email.com"
+      autocomplete="username"
       autofocus
       :help="$t('account.changePassword.emailHelp')"
     />
@@ -131,6 +132,7 @@ init()
       :label="$t('account.changePassword.currentPasswordLabel')"
       name="current_password"
       type="password"
+      autocomplete="current-password"
       :help="$t('account.changePassword.currentPasswordHelp')"
     />
 
@@ -140,6 +142,7 @@ init()
         :form="form"
         :label="$t('account.changePassword.tokenLabel')"
         name="token"
+        autocomplete="one-time-code"
         placeholder="* * * * * *"
         class-add="text-sm"
         :help="$t('account.changePassword.tokenHelp')"
@@ -152,6 +155,7 @@ init()
         :form="form"
         :label="$t('account.changePassword.newPasswordLabel')"
         name="password"
+        autocomplete="new-password"
         :disabled="!isCurve && !form.values.current_password && !form.values.private_key"
         :help="$t('account.changePassword.newPasswordHelp')"
       />

--- a/web/src/components/account/ChangePasswordForm.vue
+++ b/web/src/components/account/ChangePasswordForm.vue
@@ -138,12 +138,11 @@ init()
 
     <div class="w-1/2 sm:w-1/4">
       <AppField
-        type="password"
         :form="form"
         :label="$t('account.changePassword.tokenLabel')"
         name="token"
         autocomplete="one-time-code"
-        placeholder="* * * * * *"
+        inputmode="numeric"
         class-add="text-sm"
         :help="$t('account.changePassword.tokenHelp')"
       />

--- a/web/src/components/form/AppField.vue
+++ b/web/src/components/form/AppField.vue
@@ -19,6 +19,7 @@ const props = defineProps<{
   name: string
   form?: FormType
   type?: 'text' | 'password' | undefined
+  autocomplete?: string | undefined
   label?: string | undefined
   allowCopy?: boolean | undefined
   placeholder?: string | undefined
@@ -136,6 +137,7 @@ const copy = () => {
           @input="change"
           @change="change"
           :type="type || 'text'"
+          :autocomplete="autocomplete"
           :placeholder="placeholder || ''"
           :disabled="disabled || form?.isSubmitting.value"
           :autofocus="!!props.autofocus"

--- a/web/src/components/form/AppField.vue
+++ b/web/src/components/form/AppField.vue
@@ -20,6 +20,7 @@ const props = defineProps<{
   form?: FormType
   type?: 'text' | 'password' | undefined
   autocomplete?: string | undefined
+  inputmode?: 'numeric' | undefined
   label?: string | undefined
   allowCopy?: boolean | undefined
   placeholder?: string | undefined
@@ -138,6 +139,7 @@ const copy = () => {
           @change="change"
           :type="type || 'text'"
           :autocomplete="autocomplete"
+          :inputmode="inputmode"
           :placeholder="placeholder || ''"
           :disabled="disabled || form?.isSubmitting.value"
           :autofocus="!!props.autofocus"

--- a/web/src/views/auth/login/IndexView.vue
+++ b/web/src/views/auth/login/IndexView.vue
@@ -81,12 +81,11 @@ init()
           />
           <div class="w-1/2 sm:w-1/4">
             <AppField
-              type="password"
               :form="form"
               :label="$t('auth.login.twoFactorLabel')"
               name="token"
               autocomplete="one-time-code"
-              placeholder="* * * * * *"
+              inputmode="numeric"
               class-add="text-sm"
             />
           </div>

--- a/web/src/views/auth/login/IndexView.vue
+++ b/web/src/views/auth/login/IndexView.vue
@@ -68,6 +68,7 @@ init()
             :label="$t('auth.yourEmail')"
             name="email"
             :placeholder="$t('auth.emailPlaceholder')"
+            autocomplete="username"
             autofocus
           />
           <AppField
@@ -75,6 +76,7 @@ init()
             :form="form"
             :label="$t('auth.yourPassword')"
             name="password"
+            autocomplete="current-password"
             placeholder="***************************"
           />
           <div class="w-1/2 sm:w-1/4">
@@ -83,6 +85,7 @@ init()
               :form="form"
               :label="$t('auth.login.twoFactorLabel')"
               name="token"
+              autocomplete="one-time-code"
               placeholder="* * * * * *"
               class-add="text-sm"
             />

--- a/web/src/views/auth/pin/DecryptView.vue
+++ b/web/src/views/auth/pin/DecryptView.vue
@@ -84,6 +84,7 @@ init()
             :form="form"
             :label="$t('auth.yourPassword')"
             name="password"
+            autocomplete="off"
             placeholder="********"
             :autofocus="true"
           />

--- a/web/src/views/auth/pin/SetupLockScreenView.vue
+++ b/web/src/views/auth/pin/SetupLockScreenView.vue
@@ -73,6 +73,7 @@ config.value = {
             :form="form"
             :label="$t('auth.lockSetup.passwordLabel')"
             name="password"
+            autocomplete="off"
             placeholder="******"
           />
           <AppField
@@ -81,6 +82,7 @@ config.value = {
             :form="form"
             :label="$t('common.confirm')"
             name="confirm_password"
+            autocomplete="off"
             placeholder="******"
           />
 

--- a/web/src/views/auth/register/IndexView.vue
+++ b/web/src/views/auth/register/IndexView.vue
@@ -102,6 +102,7 @@ init()
             :label="$t('auth.yourEmail')"
             name="email"
             :placeholder="$t('auth.emailPlaceholder')"
+            autocomplete="username"
             :disabled="form.values.invitation_id"
           />
           <AppField
@@ -109,6 +110,7 @@ init()
             :form="form"
             :label="$t('auth.yourPassword')"
             name="password"
+            autocomplete="new-password"
             placeholder="*********"
           />
           <AppField
@@ -117,6 +119,7 @@ init()
             :form="form"
             :label="$t('auth.register.confirmPassword')"
             name="confirm_password"
+            autocomplete="new-password"
             placeholder="*********"
           />
           <AppButton color="info" type="submit">{{ $t('common.next') }}</AppButton>

--- a/web/src/views/auth/register/ResendActivation.vue
+++ b/web/src/views/auth/register/ResendActivation.vue
@@ -67,7 +67,13 @@ init()
         </div>
 
         <AppForm :config="config" class="mt-8 space-y-6" v-slot="{ form }">
-          <AppField :form="form" :label="$t('auth.yourEmail')" name="email" :autofocus="true" />
+          <AppField
+            :form="form"
+            :label="$t('auth.yourEmail')"
+            name="email"
+            autocomplete="username"
+            :autofocus="true"
+          />
 
           <p v-if="resendError" class="text-sm text-redish-400">
             {{ resendError }}

--- a/web/src/views/auth/register/TwoFactorView.vue
+++ b/web/src/views/auth/register/TwoFactorView.vue
@@ -127,6 +127,7 @@ init()
             :label="$t('auth.twoFactor.tokenLabel')"
             name="token"
             autocomplete="one-time-code"
+            inputmode="numeric"
           />
 
           <AppButton color="info" type="submit">

--- a/web/src/views/auth/register/TwoFactorView.vue
+++ b/web/src/views/auth/register/TwoFactorView.vue
@@ -122,7 +122,12 @@ init()
             name="secret"
             :allow-copy="true"
           />
-          <AppField :form="form" :label="$t('auth.twoFactor.tokenLabel')" name="token" />
+          <AppField
+            :form="form"
+            :label="$t('auth.twoFactor.tokenLabel')"
+            name="token"
+            autocomplete="one-time-code"
+          />
 
           <AppButton color="info" type="submit">
             {{ $t('auth.twoFactor.registerButton') }}


### PR DESCRIPTION
Password managers had no way to tell which input on the login form holds the username, the current password or a one-time code, so they guessed and frequently filled the wrong field. `AppField` gained an `autocomplete` prop and the auth forms now pass the standard tokens:

| Form | Fields |
|------|--------|
| Login | `username`, `current-password`, `one-time-code` |
| Registration | `username`, `new-password` (both) |
| Change password | `username`, `current-password`, `one-time-code`, `new-password` |
| Resend activation | `username` |
| Two-factor setup | `one-time-code` |

The lock screen PIN encrypts the locally stored private key rather than authenticating the account, so those inputs opt out with `autocomplete="off"` instead — a manager filling the account password there would only produce a failed unlock.

The two-factor token inputs also stop being `type="password"`. Masking a six-digit code that expires in thirty seconds hides it from the user and from the managers that look for a plain code field to fill the stored TOTP into. They are now text inputs with `inputmode="numeric"`, so mobile keyboards open on the numeric pad and no spinner controls appear.

Two e2e tests in `web/e2e/auth.spec.ts` assert the attributes on the login and registration pages.

Closes #189