### PR TITLE
Store CLA signatures on a branch the action can write to

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,7 +2,8 @@ name: Contributor License Agreement
 
 # Asks first-time contributors to sign CLA.md before their pull request can be
 # merged. Signatures are stored in signatures/cla.json in this repository, so
-# no third-party service holds contributor data.
+# no third-party service holds contributor data. They live on their own branch
+# because signing is a direct write, which branch protection on master rejects.
 on:
   issue_comment:
     types: [created]
@@ -27,5 +28,5 @@ jobs:
         with:
           path-to-signatures: signatures/cla.json
           path-to-document: https://github.com/hudikhq/hoodik/blob/master/CLA.md
-          branch: master
+          branch: cla-signatures
           allowlist: htunlogic,dependabot[bot]


### PR DESCRIPTION
The CLA check has failed on every pull request since it was added in #194, including ones whose only committer is on the allowlist.

The action's first act is to create `signatures/cla.json` on the branch it is pointed at. That was `master`, which is protected, so the write is rejected before the allowlist is ever consulted:

```
Error occurred when creating the signed contributors file: Could not create file:
Changes must be made through a pull request. Required status check "test" is expected.
Cannot change this locked branch. Make sure the branch where signatures are stored is
NOT protected.
```

Signing is a direct write by design, so no amount of allowlisting avoids it — the storage just cannot live on a protected branch. The signatures now go to `cla-signatures`, an orphan branch holding that one file and nothing else. Contributor data still never leaves this repository.

This has to land on `master` on its own: the workflow triggers on `pull_request_target`, which runs the workflow file from the base branch, so the same change sitting in a feature branch never executes. #196 carries an identical commit for that reason — once this merges, that one becomes a no-op and its CLA check can be re-run green.
