### PR TITLE
Fan shared-folder directory creation out to every member

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "hoodik"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/hoodik/Cargo.toml
+++ b/hoodik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoodik"
-version = "2.5.1"
+version = "2.5.2"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Tibor Hudik <hello@hudik.eu>"]

--- a/hoodik/tests/shares_basic.rs
+++ b/hoodik/tests/shares_basic.rs
@@ -1115,3 +1115,122 @@ async fn test_storage_index_rejects_synthetic_shared_with_me_id() {
     assert_eq!(body["message"], "invalid_dir_id");
     let _ = context;
 }
+
+/// A folder created inside an already-shared parent through the plain
+/// owner-only create carries no wrapped key for the recipients, so it is
+/// invisible to them until a re-share of the parent backfills it (GH
+/// #202 — the clients now avoid this by fanning new folders out through
+/// `upload-multikey`). The re-share path must insert rows for subtree
+/// entries the recipient doesn't hold yet while leaving the unchanged
+/// ones alone, and the recipient's list must keep showing a single root.
+#[actix_web::test]
+async fn test_reshare_backfills_child_created_after_share() {
+    let context = context::Context::mock_sqlite().await;
+    let app = test::init_service(server::app(context.clone())).await;
+
+    register_user!(app, context, alice, "alice@example.com");
+    register_user!(app, context, bob, "bob@example.com");
+
+    let parent = create_folder!(app, alice, "backfill-parent");
+    let members = vec![
+        crate::shares_common::FolderListMemberSpec {
+            user: &alice,
+            share_role: ShareRoleEnum::CoOwner,
+            is_owner: true,
+            signed_by: &alice,
+        },
+        crate::shares_common::FolderListMemberSpec {
+            user: &bob,
+            share_role: ShareRoleEnum::Editor,
+            is_owner: false,
+            signed_by: &alice,
+        },
+    ];
+    let envelope = build_folder_share_envelope(
+        &alice,
+        &bob,
+        ShareRoleEnum::Editor,
+        parent.id,
+        alice.user_id,
+        random_nonce(),
+        now_secs(),
+        &members,
+        &alice,
+    );
+    assert_eq!(post_share!(app, alice, envelope).status(), StatusCode::CREATED);
+
+    // Created through the plain owner-only path after the share — no row
+    // for bob, so bob's listing of the parent must not carry it.
+    let child = create_folder!(app, alice, "backfill-child", parent.id);
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/storage?dir_id={}", parent.id))
+        .cookie(bob.jwt.clone())
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let listing: Value = test::read_body_json(resp).await;
+    assert!(
+        !listing["children"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|c| c["id"] == Value::String(child.id.to_string())),
+        "plain-created child has no wrapped key for bob"
+    );
+
+    // Re-share at the same role with the full subtree: the parent row is
+    // untouched, the child row is inserted.
+    let entries = vec![
+        (parent.id, b"wrap-parent".to_vec()),
+        (child.id, b"wrap-child".to_vec()),
+    ];
+    let envelope = build_folder_share_envelope_with_entries(
+        &alice,
+        &bob,
+        ShareRoleEnum::Editor,
+        parent.id,
+        alice.user_id,
+        entries,
+        random_nonce(),
+        now_secs(),
+        &members,
+        &alice,
+    );
+    assert_eq!(post_share!(app, alice, envelope).status(), StatusCode::CREATED);
+
+    let child_row = user_files::Entity::find()
+        .filter(user_files::Column::FileId.eq(child.id))
+        .filter(user_files::Column::UserId.eq(bob.user_id))
+        .one(&context.db)
+        .await
+        .unwrap()
+        .expect("re-share backfilled bob's row on the child");
+    assert_eq!(child_row.share_role, "editor");
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/storage?dir_id={}", parent.id))
+        .cookie(bob.jwt.clone())
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let listing: Value = test::read_body_json(resp).await;
+    assert!(
+        listing["children"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|c| c["id"] == Value::String(child.id.to_string())),
+        "bob sees the child after the backfill"
+    );
+
+    // The recipient list still dedupes to the share root alone — the
+    // backfilled child must not surface as a second entry.
+    let req = test::TestRequest::get()
+        .uri("/api/shares/mine")
+        .cookie(bob.jwt.clone())
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let page: IncomingSharePage = test::read_body_json(resp).await;
+    assert_eq!(page.total, 1);
+    assert_eq!(page.items[0].file_id, parent.id);
+}

--- a/hoodik/tests/shares_editable_folders.rs
+++ b/hoodik/tests/shares_editable_folders.rs
@@ -11,6 +11,7 @@ use cryptfns::asn1::{AuditEventActionEnum, ShareRoleEnum};
 use entity::{share_events, user_files, ColumnTrait, EntityTrait, QueryFilter, Uuid};
 use hoodik::server;
 use serde_json::Value;
+use storage::data::response::Response as StorageResponse;
 
 use crate::shares_common::*;
 
@@ -1776,5 +1777,144 @@ async fn test_folder_owner_sees_full_member_roster() {
     for member in members {
         assert!(!member["email"].is_null());
     }
+    let _ = context;
+}
+
+/// The web and mobile "New folder" affordance inside a shared folder
+/// routes through `upload-multikey` with `mime: "dir"` — the regular
+/// create would wrap the folder key for the creator alone and leave the
+/// directory invisible to every other member (GH #202). This pins the
+/// server contract both clients rely on: a directory row lands with a
+/// wrapped key per member, and members see it when listing the parent.
+#[actix_web::test]
+async fn test_multikey_create_directory_fans_out_and_lists_for_members() {
+    let context = context::Context::mock_sqlite().await;
+    let app = test::init_service(server::app(context.clone())).await;
+
+    register_user!(app, context, alice, "alice@example.com");
+    register_user!(app, context, bob, "bob@example.com");
+    let folder = create_folder!(app, alice, "dir-create-root");
+    let members_after = owner_plus_recipient(&alice, &bob, ShareRoleEnum::Editor);
+    let envelope = build_folder_share_envelope(
+        &alice,
+        &bob,
+        ShareRoleEnum::Editor,
+        folder.id,
+        alice.user_id,
+        random_nonce(),
+        now_secs(),
+        &members_after,
+        &alice,
+    );
+    assert_eq!(post_share!(app, alice, envelope).status(), StatusCode::CREATED);
+
+    // Alice (the owner) creates a sub-directory through the multi-key path.
+    let new_dir_id = Uuid::new_v4();
+    let timestamp = now_secs();
+    let event_signature = sign_no_recipient_event(
+        &alice,
+        new_dir_id,
+        AuditEventActionEnum::SharedFolderUpload,
+        timestamp,
+    );
+    let mut body = build_upload_multikey_body(
+        new_dir_id,
+        folder.id,
+        "new-subfolder",
+        vec![
+            (alice.user_id, "wrap-for-alice", true),
+            (bob.user_id, "wrap-for-bob", false),
+        ],
+        timestamp,
+        None,
+        event_signature,
+        timestamp,
+    );
+    body["mime"] = serde_json::json!("dir");
+    body["chunks"] = serde_json::json!(0);
+    body["size"] = Value::Null;
+    body["sha256"] = Value::Null;
+
+    let req = test::TestRequest::post()
+        .uri("/api/storage/upload-multikey")
+        .cookie(alice.jwt.clone())
+        .set_json(&body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let rows = user_files::Entity::find()
+        .filter(user_files::Column::FileId.eq(new_dir_id))
+        .all(&context.db)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2, "one wrapped key per member");
+    assert!(rows.iter().any(|r| r.user_id == alice.user_id && r.is_owner));
+    assert!(rows.iter().any(|r| r.user_id == bob.user_id && !r.is_owner));
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/storage?dir_id={}", folder.id))
+        .cookie(bob.jwt.clone())
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let listing: StorageResponse = test::read_body_json(resp).await;
+    let created = listing
+        .children
+        .iter()
+        .find(|c| c.id == new_dir_id)
+        .expect("bob sees the directory alice created in the shared folder");
+    assert_eq!(created.mime, "dir");
+
+    // Bob continues one level deeper. The intermediate directory carries
+    // no signed member list of its own, so the client authorises the
+    // wraps against the share root's list and targets the intermediate —
+    // the snapshot check compares against the target's (unset)
+    // membership stamp and the wrap set against the target's rows.
+    let nested_dir_id = Uuid::new_v4();
+    let timestamp = now_secs();
+    let event_signature = sign_no_recipient_event(
+        &bob,
+        nested_dir_id,
+        AuditEventActionEnum::SharedFolderUpload,
+        timestamp,
+    );
+    let mut body = build_upload_multikey_body(
+        nested_dir_id,
+        new_dir_id,
+        "nested-subfolder",
+        vec![
+            (alice.user_id, "wrap-for-alice", false),
+            (bob.user_id, "wrap-for-bob", true),
+        ],
+        timestamp,
+        None,
+        event_signature,
+        timestamp,
+    );
+    body["mime"] = serde_json::json!("dir");
+    body["chunks"] = serde_json::json!(0);
+    body["size"] = Value::Null;
+    body["sha256"] = Value::Null;
+
+    let req = test::TestRequest::post()
+        .uri("/api/storage/upload-multikey")
+        .cookie(bob.jwt.clone())
+        .set_json(&body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/storage?dir_id={}", new_dir_id))
+        .cookie(alice.jwt.clone())
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let listing: StorageResponse = test::read_body_json(resp).await;
+    assert!(
+        listing.children.iter().any(|c| c.id == nested_dir_id),
+        "the owner sees the directory bob created below the share root"
+    );
     let _ = context;
 }

--- a/web/e2e/shares-folder.spec.ts
+++ b/web/e2e/shares-folder.spec.ts
@@ -157,10 +157,22 @@ test.describe('Folder shares: creating folders inside a share (GH #202)', () => 
     await page.getByRole('button', { name: 'Create', exact: true }).click()
     await expect(page.getByTestId('file-row-from-bob')).toBeVisible({ timeout: 15_000 })
 
+    // One level deeper: the intermediate folder has no signed member
+    // list of its own, so the create verifies against the share root's —
+    // and the result still reaches the other side.
+    await page.getByTestId('file-row-from-alice').dblclick()
+    await expect(page).toHaveURL(/[0-9a-f-]{36}/)
+    await page.locator('[name="create-dir"]').click()
+    await page.locator('#name').fill('bob-nested')
+    await page.getByRole('button', { name: 'Create', exact: true }).click()
+    await expect(page.getByTestId('file-row-bob-nested')).toBeVisible({ timeout: 15_000 })
+
     await logout(page)
     await loginAsUser(page, alice.email, alice.password)
     await page.getByTestId('file-row-shared-folder').dblclick()
     await expect(page.getByTestId('file-row-from-bob')).toBeVisible({ timeout: 15_000 })
+    await page.getByTestId('file-row-from-alice').dblclick()
+    await expect(page.getByTestId('file-row-bob-nested')).toBeVisible({ timeout: 15_000 })
   })
 
   test('a share opened from search lists once in Shared with me', async ({ page }) => {

--- a/web/e2e/shares-folder.spec.ts
+++ b/web/e2e/shares-folder.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 import path from 'path'
 
 import { createUser, loginAsUser, logout, randomEmail, randomPassword } from './helpers/auth'
-import { closeOpenModal, discoverRecipient } from './helpers/shares'
+import { closeOpenModal, discoverRecipient, openSharedWithMe } from './helpers/shares'
 
 const imageFixture = path.join(__dirname, 'fixtures', 'test-image.png')
 
@@ -105,5 +105,94 @@ test.describe('Folder shares: subtree walking', () => {
     const response = await page.request.get('/api/shares/mine')
     const json = (await response.json()) as { items: { owner_email: string }[] }
     expect(json.items.some((row) => row.owner_email === alice.email)).toBe(true)
+  })
+})
+
+test.describe('Folder shares: creating folders inside a share (GH #202)', () => {
+  async function shareFolderWithBob(
+    page: Parameters<typeof createUser>[0],
+    bobEmail: string
+  ): Promise<void> {
+    await page.locator('[name="create-dir"]').click()
+    await page.locator('#name').fill('shared-folder')
+    await page.getByRole('button', { name: 'Create', exact: true }).click()
+    await expect(page.getByTestId('file-row-shared-folder')).toBeVisible({ timeout: 15_000 })
+
+    await closeOpenModal(page)
+    await page.getByTestId('file-row-shared-folder').locator('[name="actions-dropdown"]').click()
+    await page.getByTestId('actions-share-account').first().click()
+    await discoverRecipient(page, bobEmail)
+    await page.getByTestId('share-dialog-role-editor').check()
+    await page.getByTestId('share-dialog-submit').click()
+    await expect(page.getByTestId('share-dialog-target')).toHaveCount(0, { timeout: 60_000 })
+  }
+
+  test('folders created inside a shared folder are visible to the other side', async ({
+    page
+  }) => {
+    const { alice, bob } = await registerTwo(page)
+    await loginAsUser(page, alice.email, alice.password)
+    await shareFolderWithBob(page, bob.email)
+
+    // Owner creates a folder inside the already-shared folder. The
+    // create runs through the multi-key path, so Bob must receive a
+    // wrapped key for it.
+    await page.getByTestId('file-row-shared-folder').dblclick()
+    await expect(page).toHaveURL(/[0-9a-f-]{36}/)
+    await page.locator('[name="create-dir"]').click()
+    await page.locator('#name').fill('from-alice')
+    await page.getByRole('button', { name: 'Create', exact: true }).click()
+    await expect(page.getByTestId('file-row-from-alice')).toBeVisible({ timeout: 15_000 })
+
+    await logout(page)
+    await loginAsUser(page, bob.email, bob.password)
+    await openSharedWithMe(page)
+    await page.getByTestId('file-row-shared-folder').dblclick()
+    await expect(page.getByTestId('file-row-from-alice')).toBeVisible({ timeout: 15_000 })
+
+    // The editor can create a folder here too — the affordance used to
+    // be hidden for recipients — and the owner sees the result.
+    await page.locator('[name="create-dir"]').click()
+    await page.locator('#name').fill('from-bob')
+    await page.getByRole('button', { name: 'Create', exact: true }).click()
+    await expect(page.getByTestId('file-row-from-bob')).toBeVisible({ timeout: 15_000 })
+
+    await logout(page)
+    await loginAsUser(page, alice.email, alice.password)
+    await page.getByTestId('file-row-shared-folder').dblclick()
+    await expect(page.getByTestId('file-row-from-bob')).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('a share opened from search lists once in Shared with me', async ({ page }) => {
+    const { alice, bob } = await registerTwo(page)
+    await loginAsUser(page, alice.email, alice.password)
+    await shareFolderWithBob(page, bob.email)
+
+    await logout(page)
+    await loginAsUser(page, bob.email, bob.password)
+
+    // Enter the shared folder through a search hit, so its row lands in
+    // the store under its real parent before the virtual folder was ever
+    // listed. Re-listing "Shared with me" twice afterwards used to
+    // duplicate the row (GH #202).
+    await closeOpenModal(page)
+    await page.getByRole('button', { name: /Search/ }).first().click()
+    const searchInput = page.locator('input[placeholder="Search files..."]')
+    await expect(searchInput).toBeVisible({ timeout: 10_000 })
+    await searchInput.fill('shared-folder')
+    const hit = page.getByRole('link', { name: /shared-folder\// }).first()
+    await expect(hit).toBeVisible({ timeout: 15_000 })
+    await hit.click()
+    await page.waitForURL(/[0-9a-f-]{36}/, { timeout: 15_000 })
+
+    // Back to the root, then list the virtual folder twice.
+    await page.locator('aside').locator(':text-is("Files")').first().click()
+    await expect(page.getByTestId('file-row-Shared with me')).toBeVisible({ timeout: 15_000 })
+    await openSharedWithMe(page)
+    await page.locator('aside').locator(':text-is("Files")').first().click()
+    await expect(page.getByTestId('file-row-Shared with me')).toBeVisible({ timeout: 15_000 })
+    await openSharedWithMe(page)
+
+    await expect(page.getByTestId('file-row-shared-folder')).toHaveCount(1)
   })
 })

--- a/web/services/shares/editable-members.ts
+++ b/web/services/shares/editable-members.ts
@@ -336,6 +336,30 @@ export async function verifyAndReconcile(
  * the fresh roster is re-verified and re-reconciled before the single retry;
  * any other error — and a second conflict — propagates unchanged.
  */
+/**
+ * Bind a roster fetch to one folder id: the returned closure fetches that
+ * folder's member list and refuses a response whose `folder_id` differs
+ * from the id it asked about. The list signature only authenticates the
+ * roster *for the folder named inside the canonical* — without this
+ * check a hostile server could satisfy the verification with any other
+ * validly signed roster of the same owner.
+ */
+export function rosterFetcher(
+  rosterFolderId: string,
+  fetchMembers: (folderId: string) => Promise<FolderMembersResponse>
+): () => Promise<FolderMembersResponse> {
+  return async () => {
+    const response = await fetchMembers(rosterFolderId)
+    if (response.folder_id !== rosterFolderId) {
+      throw new FolderMemberListInvalid(
+        'folder_mismatch',
+        `Member list is for folder ${response.folder_id}, not the requested ${rosterFolderId}.`
+      )
+    }
+    return response
+  }
+}
+
 export async function withMembershipRetry<T>(
   initial: FolderMembersResponse,
   reverify: (snapshot: FolderMembersResponse) => Promise<void>,

--- a/web/services/shares/editable-members.ts
+++ b/web/services/shares/editable-members.ts
@@ -339,13 +339,19 @@ export async function verifyAndReconcile(
 export async function withMembershipRetry<T>(
   initial: FolderMembersResponse,
   reverify: (snapshot: FolderMembersResponse) => Promise<void>,
-  submit: (snapshot: FolderMembersResponse) => Promise<T>
+  submit: (snapshot: FolderMembersResponse) => Promise<T>,
+  refetch?: () => Promise<FolderMembersResponse>
 ): Promise<T> {
   try {
     return await submit(initial)
   } catch (err) {
     if (err instanceof api.ShareMembershipChangedError) {
-      const refreshed = err.currentMembers
+      // The 409 payload carries the roster of the folder the write
+      // targeted. When the wrap fan-out was authorised by a different
+      // folder's signed list (a create below the share root), that
+      // payload has no signature to verify, so the caller supplies a
+      // refetch of the signed roster instead.
+      const refreshed = refetch ? await refetch() : err.currentMembers
       await reverify(refreshed)
       return submit(refreshed)
     }

--- a/web/services/shares/editable-move.ts
+++ b/web/services/shares/editable-move.ts
@@ -3,6 +3,7 @@ import * as shareCrypto from './crypto'
 import * as subtree from './subtree'
 import {
   ensureNotAborted,
+  rosterFetcher,
   verifyAndReconcile,
   withMembershipRetry,
   wrapForEveryMember
@@ -38,6 +39,9 @@ export async function moveSingleFileIntoSharedFolder(
     callerWrappingPrivateKey: string
     file: AppFile
     destinationFolderId: string
+    /** Folder whose signed member list authorises the wraps when the
+     *  destination is below a share root — see `UploadIntoSharedFolderArgs`. */
+    rosterFolderId?: string
     trustedFingerprints: TrustedFingerprintsStore
     onUnknownMember?: (prompt: UnknownMemberPrompt) => Promise<boolean>
   },
@@ -49,6 +53,10 @@ export async function moveSingleFileIntoSharedFolder(
 ): Promise<void> {
   ensureNotAborted(options.signal)
   const fetchMembers = options.fetchMembers ?? api.getFolderMembers
+  const fetchRoster = rosterFetcher(
+    args.rosterFolderId ?? args.destinationFolderId,
+    fetchMembers
+  )
   const poster = options.postMove ?? api.moveIntoShared
 
   const fileKeyHex = await shareCrypto.decryptOwnFileKey(
@@ -56,7 +64,7 @@ export async function moveSingleFileIntoSharedFolder(
     args.callerWrappingPrivateKey
   )
 
-  const response = await fetchMembers(args.destinationFolderId)
+  const response = await fetchRoster()
   await verifyAndReconcile(
     response,
     args.callerUserId,
@@ -106,7 +114,8 @@ export async function moveSingleFileIntoSharedFolder(
         args.trustedFingerprints,
         args.onUnknownMember
       ),
-    submit
+    submit,
+    fetchRoster
   )
 }
 
@@ -129,6 +138,10 @@ export async function moveIntoSharedFolder(
 ): Promise<void> {
   ensureNotAborted(options.signal)
   const fetchMembers = options.fetchMembers ?? api.getFolderMembers
+  const fetchRoster = rosterFetcher(
+    args.rosterFolderId ?? args.destinationFolderId,
+    fetchMembers
+  )
   const walk = options.collectSubtree ?? ((root: AppFile) =>
     subtree.collectSubtree(root, {
       signal: options.signal,
@@ -138,7 +151,7 @@ export async function moveIntoSharedFolder(
 
   const nodes = await walk(args.root)
 
-  const response = await fetchMembers(args.destinationFolderId)
+  const response = await fetchRoster()
   options.onProgress?.({
     wrappedKeys: 0,
     totalKeys: nodes.length * response.members.length,
@@ -220,7 +233,8 @@ export async function moveIntoSharedFolder(
         args.trustedFingerprints,
         args.onUnknownMember
       ),
-    submit
+    submit,
+    fetchRoster
   )
 }
 

--- a/web/services/shares/editable-types.ts
+++ b/web/services/shares/editable-types.ts
@@ -100,7 +100,7 @@ export interface SharedFolderFilePayload {
   encryptedName: string
   encryptedThumbnail?: string
   mime: string
-  size: number
+  size?: number
   chunks: number
   sha256?: string
   cipher: string
@@ -120,6 +120,16 @@ export interface UploadIntoSharedFolderArgs {
   /** PEM-encoded caller public key (echoed only — wraps for the caller come from `fileKeyHex`). */
   callerPublicKey: string
   payload: SharedFolderFilePayload
+  /**
+   * Folder whose signed member list authorises the wrap fan-out, when it
+   * isn't the direct parent. Folders below a share root carry the same
+   * roster as the root (fan-out, cascade moves and multi-key creates all
+   * copy it) but no signature of their own, so a create inside one
+   * verifies against the root's signed list; the server still checks the
+   * supplied wraps against the actual parent's member rows. Defaults to
+   * `payload.parentFileId`.
+   */
+  rosterFolderId?: string
   trustedFingerprints: TrustedFingerprintsStore
   onUnknownMember?: (prompt: UnknownMemberPrompt) => Promise<boolean>
 }

--- a/web/services/shares/editable-types.ts
+++ b/web/services/shares/editable-types.ts
@@ -25,6 +25,7 @@ export class FolderMemberListInvalid extends Error {
     | 'fingerprint_mismatch'
     | 'unknown_signer'
     | 'owner_missing'
+    | 'folder_mismatch'
   readonly userId: string | null
 
   constructor(
@@ -162,6 +163,9 @@ export interface MoveIntoSharedFolderArgs {
   /** The moved folder root. Its full subtree is enumerated and re-wrapped. */
   root: AppFile
   destinationFolderId: string
+  /** Folder whose signed member list authorises the wraps when the
+   *  destination is below a share root — see `UploadIntoSharedFolderArgs`. */
+  rosterFolderId?: string
   trustedFingerprints: TrustedFingerprintsStore
   onUnknownMember?: (prompt: UnknownMemberPrompt) => Promise<boolean>
 }

--- a/web/services/shares/editable-upload.ts
+++ b/web/services/shares/editable-upload.ts
@@ -4,6 +4,7 @@ import * as api from './api'
 import * as shareCrypto from './crypto'
 import {
   ensureNotAborted,
+  rosterFetcher,
   verifyAndReconcile,
   withMembershipRetry,
   wrapForEveryMember
@@ -40,8 +41,12 @@ export async function uploadIntoSharedFolder(
 ): Promise<UploadMultiKeyResponse> {
   ensureNotAborted(options.signal)
   const fetchMembers = options.fetchMembers ?? api.getFolderMembers
+  const fetchRoster = rosterFetcher(
+    args.rosterFolderId ?? args.payload.parentFileId,
+    fetchMembers
+  )
 
-  const response = await fetchMembers(args.rosterFolderId ?? args.payload.parentFileId)
+  const response = await fetchRoster()
   options.onProgress?.({
     wrappedKeys: 0,
     totalKeys: response.members.length,
@@ -137,7 +142,7 @@ export async function uploadIntoSharedFolder(
         args.onUnknownMember
       ),
     submit,
-    () => fetchMembers(args.rosterFolderId ?? args.payload.parentFileId)
+    fetchRoster
   )
 }
 

--- a/web/services/shares/editable-upload.ts
+++ b/web/services/shares/editable-upload.ts
@@ -41,7 +41,7 @@ export async function uploadIntoSharedFolder(
   ensureNotAborted(options.signal)
   const fetchMembers = options.fetchMembers ?? api.getFolderMembers
 
-  const response = await fetchMembers(args.payload.parentFileId)
+  const response = await fetchMembers(args.rosterFolderId ?? args.payload.parentFileId)
   options.onProgress?.({
     wrappedKeys: 0,
     totalKeys: response.members.length,
@@ -136,7 +136,8 @@ export async function uploadIntoSharedFolder(
         args.trustedFingerprints,
         args.onUnknownMember
       ),
-    submit
+    submit,
+    () => fetchMembers(args.rosterFolderId ?? args.payload.parentFileId)
   )
 }
 

--- a/web/services/storage/index.ts
+++ b/web/services/storage/index.ts
@@ -766,11 +766,74 @@ export const store = defineStore('files', () => {
   }
 
   /**
-   * Create a directory in the storage. A parent that is a shared folder
+   * Nearest ancestor-or-self folder of `dirId` that carries a signed
+   * member list — the folder whose list authorises a multi-key write
+   * anywhere in its subtree. Folders below a share root hold the root's
+   * roster (fan-out, cascade moves and multi-key creates all copy it)
+   * but no signature of their own, and the server rejects any write
+   * whose wrap set doesn't match the actual target's rows, so resolving
+   * at the root is exactly as strong as writing into the root itself.
+   *
+   * Walks the store first — the breadcrumb chain of any folder the user
+   * navigated into is already there — and falls back to one listing
+   * fetch for rows the store doesn't hold (a move-picker destination).
+   * Returns null for a private tree or a pre-signature legacy share.
+   */
+  async function resolveRosterFolder(
+    dirId: string | null | undefined
+  ): Promise<AppFile | null> {
+    if (!dirId || dirId === SHARED_WITH_ME_DIR_ID) return null
+
+    const seen = new Set<string>()
+    let cursor: string | null = dirId
+    while (cursor && cursor !== SHARED_WITH_ME_DIR_ID && !seen.has(cursor)) {
+      seen.add(cursor)
+      const row = getItem(cursor)
+      if (!row) {
+        try {
+          const response = await meta.find({ dir_id: dirId })
+          const parents = (response.parents ?? []) as AppFile[]
+          // `parents` runs root-first and includes the target itself, so
+          // the nearest signed folder is the last match.
+          for (let i = parents.length - 1; i >= 0; i--) {
+            if (parents[i].members_signed_at != null) return parents[i]
+          }
+        } catch {
+          // Unknown folder — treated the same as an unsigned chain.
+        }
+        return null
+      }
+      if (row.mime !== 'dir') return null
+      if (row.members_signed_at != null) return row
+      cursor = row.file_id ?? null
+    }
+    return null
+  }
+
+  /**
+   * Roster source for a write into `dirId`, or undefined for a plain
+   * owner-only write. A non-owned folder with no signed list anywhere in
+   * its chain (a pre-signature legacy share) falls back to the folder
+   * itself, so those writes keep today's verification error instead of
+   * silently producing an owner-only row.
+   */
+  async function writeRosterId(
+    dirId: string | null | undefined
+  ): Promise<string | undefined> {
+    if (!dirId || dirId === SHARED_WITH_ME_DIR_ID) return undefined
+    const resolved = await resolveRosterFolder(dirId)
+    if (resolved) return resolved.id
+    const row = getItem(dirId)
+    return row && row.mime === 'dir' && row.is_owner === false ? row.id : undefined
+  }
+
+  /**
+   * Create a directory in the storage. A parent inside a shared tree
    * routes through the multi-key create so every member receives a wrap
    * of the folder key — the regular create would leave the new directory
-   * visible to the creator alone. `rosterFolderId` carries the signed
-   * roster source for creates below a share root (folder uploads).
+   * visible to the creator alone. `rosterFolderId` carries a caller-
+   * resolved roster source (folder uploads resolve once for the whole
+   * batch); without it the parent's chain is resolved here.
    */
   async function createDir(
     keypair: KeyPair,
@@ -780,23 +843,21 @@ export const store = defineStore('files', () => {
     rosterFolderId?: string
   ): Promise<AppFile> {
     const parent = dir_id ? getItem(dir_id) : undefined
-    // Loaded lazily for the same reason `find` pulls the shares API in on
-    // demand — the multi-key pipeline stays out of the boot bundle.
-    const save = await import('./save')
+    const roster = rosterFolderId ?? (parent ? await writeRosterId(dir_id) : undefined)
 
-    // `rosterFolderId` marks the create as part of a shared tree even
-    // when the immediate parent is an unsigned intermediate directory
-    // the caller just created.
-    if (parent && (rosterFolderId != null || save.needsMultikeyCreate(parent))) {
+    if (parent && roster != null) {
       if (!callerUserId) {
         throw new Error('Cannot create directory in a shared folder without caller id')
       }
+      // Loaded lazily for the same reason `find` pulls the shares API in
+      // on demand — the multi-key pipeline stays out of the boot bundle.
+      const save = await import('./save')
       const dir = await save.createDirInSharedFolder(
         keypair,
         name,
         parent as AppFile,
         callerUserId,
-        rosterFolderId
+        roster
       )
       upsertItem(dir)
       emitFileTreeChange({ type: 'created', folderId: dir_id })
@@ -933,6 +994,7 @@ export const store = defineStore('files', () => {
     rename,
     replaceItem,
     reset,
+    resolveRosterFolder,
     selectAll,
     selected,
     selectOne,
@@ -945,7 +1007,8 @@ export const store = defineStore('files', () => {
     takeItem,
     title,
     updateItem,
-    upsertItem
+    upsertItem,
+    writeRosterId
   }
 })
 

--- a/web/services/storage/index.ts
+++ b/web/services/storage/index.ts
@@ -613,10 +613,14 @@ export const store = defineStore('files', () => {
   }
 
   /**
-   * Add or update a new item in the list
+   * Add or update a new item in the list. Matched on id alone, like
+   * `upsertMany` — a row whose placement changed (a shared folder first
+   * seen under its real parent, then re-listed under the synthetic
+   * `__shared_with_me__` folder) replaces the existing copy instead of
+   * landing next to it and rendering the same file twice.
    */
   function upsertItem(item: AppFile): void {
-    if (hasItem(item.id, item.file_id || null)) {
+    if (getItem(item.id)) {
       updateItem(item)
     } else {
       addItem({ ...item, temporaryId: uuidv4() })
@@ -658,13 +662,6 @@ export const store = defineStore('files', () => {
   function takeItem(id: string): AppFile | null {
     const index = _items.value.findIndex((item) => item.id === id)
     return _items.value.slice(index, 1)[0] || null
-  }
-
-  /**
-   * Remove item from the list
-   */
-  function hasItem(id: string, file_id: string | null): boolean {
-    return _items.value.findIndex((item) => item.id === id && item.file_id === file_id) !== -1
   }
 
   /**
@@ -769,9 +766,43 @@ export const store = defineStore('files', () => {
   }
 
   /**
-   * Create a directory in the storage
+   * Create a directory in the storage. A parent that is a shared folder
+   * routes through the multi-key create so every member receives a wrap
+   * of the folder key — the regular create would leave the new directory
+   * visible to the creator alone. `rosterFolderId` carries the signed
+   * roster source for creates below a share root (folder uploads).
    */
-  async function createDir(keypair: KeyPair, name: string, dir_id?: string): Promise<AppFile> {
+  async function createDir(
+    keypair: KeyPair,
+    name: string,
+    dir_id?: string,
+    callerUserId?: string,
+    rosterFolderId?: string
+  ): Promise<AppFile> {
+    const parent = dir_id ? getItem(dir_id) : undefined
+    // Loaded lazily for the same reason `find` pulls the shares API in on
+    // demand — the multi-key pipeline stays out of the boot bundle.
+    const save = await import('./save')
+
+    // `rosterFolderId` marks the create as part of a shared tree even
+    // when the immediate parent is an unsigned intermediate directory
+    // the caller just created.
+    if (parent && (rosterFolderId != null || save.needsMultikeyCreate(parent))) {
+      if (!callerUserId) {
+        throw new Error('Cannot create directory in a shared folder without caller id')
+      }
+      const dir = await save.createDirInSharedFolder(
+        keypair,
+        name,
+        parent as AppFile,
+        callerUserId,
+        rosterFolderId
+      )
+      upsertItem(dir)
+      emitFileTreeChange({ type: 'created', folderId: dir_id })
+      return dir
+    }
+
     const createFile: CreateFile = {
       name,
       mime: 'dir',
@@ -887,7 +918,6 @@ export const store = defineStore('files', () => {
     firstRootListing,
     getItem,
     getSort,
-    hasItem,
     items,
     loading,
     loadStats,

--- a/web/services/storage/moveInto.ts
+++ b/web/services/storage/moveInto.ts
@@ -30,7 +30,12 @@ export function isSharedFolder(file: AppFile | null | undefined): boolean {
 export type MoveDecision =
   | { kind: 'plain'; sources: AppFile[]; destinationId: string | undefined }
   | { kind: 'blocked'; message: string }
-  | { kind: 'into-shared'; sources: AppFile[]; destinationFolderId: string }
+  | {
+      kind: 'into-shared'
+      sources: AppFile[]
+      destinationFolderId: string
+      rosterFolderId?: string
+    }
   | { kind: 'move-out'; sources: AppFile[]; destinationId: string | undefined }
 
 /**
@@ -50,13 +55,18 @@ export function classifyMove(args: {
   destination: AppFile | undefined
   sourceParent: AppFile | null
   sharingEnabled: boolean
+  /** Resolved roster source for the destination (`Storage.writeRosterId`).
+   *  Set for any destination inside a shared tree — including folders
+   *  below the share root, which `isSharedFolder` alone can't see. */
+  destinationRosterId?: string
 }): MoveDecision {
-  const { sources, destination, sourceParent, sharingEnabled } = args
+  const { sources, destination, sourceParent, sharingEnabled, destinationRosterId } = args
   if (sources.length === 0) {
     return { kind: 'plain', sources, destinationId: destination?.id }
   }
 
-  const destShared = sharingEnabled && isSharedFolder(destination)
+  const destShared =
+    sharingEnabled && (destinationRosterId != null || isSharedFolder(destination))
   if (destShared && destination) {
     if (sources.some((f) => !f.is_owner)) {
       return {
@@ -64,7 +74,12 @@ export function classifyMove(args: {
         message: 'You can only move files you own into a shared folder.'
       }
     }
-    return { kind: 'into-shared', sources, destinationFolderId: destination.id }
+    return {
+      kind: 'into-shared',
+      sources,
+      destinationFolderId: destination.id,
+      rosterFolderId: destinationRosterId
+    }
   }
 
   const sourceShared = sharingEnabled && isSharedFolder(sourceParent)
@@ -137,6 +152,7 @@ export async function executeMove(
                 callerWrappingPrivateKey: wrappingPrivateKey,
                 root: item,
                 destinationFolderId: decision.destinationFolderId,
+                rosterFolderId: decision.rosterFolderId,
                 trustedFingerprints: trusted,
                 onUnknownMember
               },
@@ -155,6 +171,7 @@ export async function executeMove(
               callerWrappingPrivateKey: wrappingPrivateKey,
               file: item,
               destinationFolderId: decision.destinationFolderId,
+              rosterFolderId: decision.rosterFolderId,
               trustedFingerprints: trusted,
               onUnknownMember
             })

--- a/web/services/storage/save.ts
+++ b/web/services/storage/save.ts
@@ -382,3 +382,58 @@ async function createNoteInSharedFolder(args: {
 
   return await meta.get(args.keypair, newFileId)
 }
+
+/**
+ * Create a directory inside a shared folder through the multi-key
+ * pipeline, so every current member receives an RSA-wrapped copy of the
+ * folder key and can decrypt its name. The regular `POST /api/storage`
+ * create wraps the key for the creator alone, which leaves the folder
+ * invisible to everyone else on the share.
+ *
+ * `rosterFolderId` points at the folder whose signed member list
+ * authorises the fan-out when the direct parent doesn't carry one (a
+ * directory created below the share root during a folder upload).
+ */
+export async function createDirInSharedFolder(
+  keypair: KeyPair,
+  name: string,
+  parent: AppFile,
+  callerUserId: string,
+  rosterFolderId?: string
+): Promise<AppFile> {
+  if (!keypair.input || !keypair.publicKey) {
+    throw new Error('Cannot create directory without an active keypair')
+  }
+
+  const cipher = cryptfns.cipher.defaultCipher()
+  const fileKey = await cryptfns.cipher.generateKey(cipher)
+  const rootKey = cryptfns.searchRootKey(keypair)
+  const indexed = name.toLowerCase()
+  const newFileId = uuidv4()
+
+  const uploadArgs: UploadIntoSharedFolderArgs = {
+    callerUserId,
+    callerPrivateKey: keypair.input,
+    callerPublicKey: keypair.publicKey,
+    payload: {
+      newFileId,
+      parentFileId: parent.id,
+      fileKeyHex: cryptfns.uint8.toHex(fileKey),
+      nameHash: cryptfns.searchTag(rootKey, name),
+      encryptedName: await cryptfns.cipher.encryptString(cipher, name, fileKey),
+      mime: 'dir',
+      chunks: 0,
+      cipher,
+      fileModifiedAt: utcStringFromLocal(new Date()),
+      searchTokensRoot: cryptfns.searchTags(rootKey, indexed),
+      searchTokensFile: cryptfns.searchTags(cryptfns.searchFileKey(fileKey), indexed)
+    },
+    rosterFolderId,
+    trustedFingerprints: trustedFingerprintsStore(),
+    onUnknownMember: async () => true
+  }
+
+  await uploadIntoSharedFolder(uploadArgs)
+
+  return await meta.get(keypair, newFileId)
+}

--- a/web/services/storage/save.ts
+++ b/web/services/storage/save.ts
@@ -223,7 +223,8 @@ export async function createNote(
   keypair: KeyPair,
   name: string,
   parent?: AppFile | string | null,
-  callerUserId?: string
+  callerUserId?: string,
+  rosterFolderId?: string
 ): Promise<AppFile> {
   const fileName = name.endsWith('.md') ? name : `${name}.md`
 
@@ -244,8 +245,7 @@ export async function createNote(
     }
   }
 
-  if (needsMultikeyCreate(parentFile)) {
-    if (!parentFile) throw new Error('Cannot create file without parent context')
+  if (parentFile && (rosterFolderId != null || needsMultikeyCreate(parentFile))) {
     if (!keypair.input || !keypair.publicKey) {
       throw new Error('Cannot create file without an active keypair')
     }
@@ -257,7 +257,8 @@ export async function createNote(
       callerUserId,
       parent: parentFile,
       fileName,
-      contentBytes
+      contentBytes,
+      rosterFolderId
     })
   }
 
@@ -302,6 +303,7 @@ async function createNoteInSharedFolder(args: {
   parent: AppFile
   fileName: string
   contentBytes: Uint8Array
+  rosterFolderId?: string
 }): Promise<AppFile> {
   const cipher = cryptfns.cipher.defaultCipher()
   const fileKey = await cryptfns.cipher.generateKey(cipher)
@@ -335,6 +337,7 @@ async function createNoteInSharedFolder(args: {
       contentTokensRoot: cryptfns.searchTags(rootKey, body),
       contentTokensFile: cryptfns.searchTags(cryptfns.searchFileKey(fileKey), body)
     },
+    rosterFolderId: args.rosterFolderId,
     trustedFingerprints: trustedFingerprintsStore(),
     onUnknownMember: async () => true
   }

--- a/web/services/storage/upload/index.ts
+++ b/web/services/storage/upload/index.ts
@@ -308,6 +308,7 @@ export const store = defineStore('upload', () => {
       onProgress?: (p: UploadIntoSharedFolderProgress) => void
       signal?: AbortSignal
       onUnknownMember?: UploadIntoSharedFolderArgs['onUnknownMember']
+      rosterFolderId?: string
     } = {}
   ): Promise<UploadAppFile> {
     logger.info(
@@ -427,6 +428,7 @@ export const store = defineStore('upload', () => {
       onProgress?: (p: UploadIntoSharedFolderProgress) => void
       signal?: AbortSignal
       onUnknownMember?: UploadIntoSharedFolderArgs['onUnknownMember']
+      rosterFolderId?: string
     } = {}
   ): Promise<UploadAppFile> {
     if (!keypair.input || !keypair.publicKey) {
@@ -457,6 +459,7 @@ export const store = defineStore('upload', () => {
       callerUserId,
       callerPrivateKey: keypair.input,
       callerPublicKey: keypair.publicKey,
+      rosterFolderId: options.rosterFolderId,
       payload: {
         newFileId,
         parentFileId: parentFolder.id,

--- a/web/src/components/files/modals/CreateDirectoryModal.vue
+++ b/web/src/components/files/modals/CreateDirectoryModal.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
   modelValue?: boolean | undefined
   Storage: FilesStore
   Crypto: CryptoStore
+  authenticatedUserId?: string
 }>()
 
 const emit = defineEmits(['update:modelValue', 'cancel', 'confirm'])
@@ -32,7 +33,12 @@ const init = () => {
     }),
     onSubmit: async (values: { name: string }, ctx: any) => {
       try {
-        await props.Storage.createDir(props.Crypto.keypair, values.name, props.Storage.dir?.id)
+        await props.Storage.createDir(
+          props.Crypto.keypair,
+          values.name,
+          props.Storage.dir?.id,
+          props.authenticatedUserId
+        )
         ctx.resetForm()
         props.Storage.find(props.Crypto.keypair, props.Storage.dir?.id || undefined)
         emit('confirm')

--- a/web/src/components/files/modals/CreateFileModal.vue
+++ b/web/src/components/files/modals/CreateFileModal.vue
@@ -43,7 +43,8 @@ const init = () => {
           props.Crypto.keypair,
           values.name,
           parent,
-          props.authenticatedUserId
+          props.authenticatedUserId,
+          parent ? await props.Storage.writeRosterId(parent.id) : undefined
         )
 
         emitFileTreeChange({ type: 'created', folderId })

--- a/web/src/components/files/modals/MoveMultipleModal.vue
+++ b/web/src/components/files/modals/MoveMultipleModal.vue
@@ -85,7 +85,8 @@ const select = async (file?: AppFile) => {
     sources: props.Storage.selected,
     destination: file,
     sourceParent: props.Storage.dir,
-    sharingEnabled: sharingEnabled.value
+    sharingEnabled: sharingEnabled.value,
+    destinationRosterId: file ? await props.Storage.writeRosterId(file.id) : undefined
   })
 
   if (decision.kind === 'blocked') {

--- a/web/src/components/shares/FolderMembersView.vue
+++ b/web/src/components/shares/FolderMembersView.vue
@@ -12,6 +12,7 @@ import BaseIcon from '@/components/ui/BaseIcon.vue'
 import BaseButton from '@/components/ui/BaseButton.vue'
 import RevokeConfirmModal from '@/components/shares/RevokeConfirmModal.vue'
 import { api as sharesApi, crypto as shareCrypto, editable as editableSvc } from '!/shares'
+import { store as filesStoreFactory } from '!/storage'
 import { errorNotification, notification, humanizeError } from '!/index'
 
 import type {
@@ -38,9 +39,12 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const files = filesStoreFactory()
+
+type SignatureStatus = 'verified' | 'via-root' | 'failed' | 'unsigned'
 
 const response = ref<FolderMembersResponse | null>(null)
-const signatureStatus = ref<Record<string, 'verified' | 'failed' | 'unsigned'>>({})
+const signatureStatus = ref<Record<string, SignatureStatus>>({})
 const loading = ref(false)
 const loadError = ref<string | null>(null)
 const revokeConfirm = ref<{
@@ -69,34 +73,83 @@ async function refresh(): Promise<void> {
  * The per-row badge reflects whether the member's presence in the list
  * is covered by a verified `FolderMemberListV1` signature. The list
  * signature is the primary authentication — every member named in a
- * list whose signature verifies is itself verified. Truly legacy rows
- * (shares from before this protocol existed) are the only case where we
- * surface "no signature".
+ * list whose signature verifies is itself verified. A folder below a
+ * share root has no signature of its own, so its roster verifies
+ * against the nearest signed ancestor's list — the same resolution
+ * every multi-key write uses. Truly legacy rows (shares from before
+ * this protocol existed) are the only case left surfacing "no
+ * signature".
  */
 async function verifySignatures(payload: FolderMembersResponse): Promise<void> {
-  const statuses: Record<string, 'verified' | 'failed' | 'unsigned'> = {}
   const hasListSignature = Boolean(payload.members_list_signature)
-  const fallback: 'verified' | 'unsigned' = hasListSignature
-    ? 'verified'
-    : 'unsigned'
+  if (!hasListSignature) {
+    const viaRoot = await verifyViaAncestor(payload)
+    if (viaRoot) {
+      signatureStatus.value = viaRoot
+      return
+    }
+    const statuses: Record<string, SignatureStatus> = {}
+    for (const member of payload.members) {
+      statuses[member.user_id] = 'unsigned'
+    }
+    signatureStatus.value = statuses
+    return
+  }
+
+  const statuses: Record<string, SignatureStatus> = {}
   try {
     await editableSvc.verifyFolderMemberList(payload)
     for (const member of payload.members) {
-      statuses[member.user_id] = fallback
+      statuses[member.user_id] = 'verified'
     }
   } catch (err) {
     if (err instanceof editableSvc.FolderMemberListInvalid && err.userId) {
       for (const member of payload.members) {
         statuses[member.user_id] =
-          member.user_id === err.userId ? 'failed' : fallback
+          member.user_id === err.userId ? 'failed' : 'verified'
       }
     } else {
       for (const member of payload.members) {
-        statuses[member.user_id] = hasListSignature ? 'failed' : 'unsigned'
+        statuses[member.user_id] = 'failed'
       }
     }
   }
   signatureStatus.value = statuses
+}
+
+/**
+ * Verify a signature-less roster against the nearest signed ancestor: a
+ * member is covered when the ancestor's verified list names the same
+ * user with the same key fingerprint and role — rosters below a share
+ * root are copies of the root's, so any deviation is worth a red badge.
+ * Returns null when there is no signed ancestor (a true legacy share)
+ * or its list cannot be verified, leaving the plain "unsigned" state.
+ */
+async function verifyViaAncestor(
+  payload: FolderMembersResponse
+): Promise<Record<string, SignatureStatus> | null> {
+  try {
+    const source = await files.resolveRosterFolder(props.folder.id)
+    if (!source || source.id === props.folder.id) return null
+    const roster = await sharesApi.getFolderMembers(source.id)
+    if (roster.folder_id !== source.id) return null
+    await editableSvc.verifyFolderMemberList(roster)
+
+    const covered = new Set(
+      roster.members.map((m) => `${m.user_id}|${m.pubkey_fingerprint}|${m.share_role}`)
+    )
+    const statuses: Record<string, SignatureStatus> = {}
+    for (const member of payload.members) {
+      statuses[member.user_id] = covered.has(
+        `${member.user_id}|${member.pubkey_fingerprint}|${member.share_role}`
+      )
+        ? 'via-root'
+        : 'failed'
+    }
+    return statuses
+  } catch {
+    return null
+  }
 }
 
 const members = computed<FolderMember[]>(() => response.value?.members ?? [])
@@ -392,6 +445,14 @@ function cancelRevoke(): void {
                 class="inline-flex items-center text-greeny-600 dark:text-greeny-300 shrink-0"
                 :data-testid="`folder-members-view-row-${member.user_id}-sig-verified`"
                 :title="$t('shares.members.sigVerified')"
+              >
+                <BaseIcon :path="mdiCheckCircle" :size="12" />
+              </span>
+              <span
+                v-else-if="signatureStatus[member.user_id] === 'via-root'"
+                class="inline-flex items-center text-greeny-600 dark:text-greeny-300 shrink-0"
+                :data-testid="`folder-members-view-row-${member.user_id}-sig-via-root`"
+                :title="$t('shares.members.sigViaRoot')"
               >
                 <BaseIcon :path="mdiCheckCircle" :size="12" />
               </span>

--- a/web/src/layouts/components/LayoutFileBrowserInner.vue
+++ b/web/src/layouts/components/LayoutFileBrowserInner.vue
@@ -290,11 +290,11 @@ const downloadMany = async () => {
 /**
  * Takes the FileList object and adds all the selected files into upload queue.
  *
- * Branches on the target directory's ownership: when the parent is a
- * shared folder where the caller is NOT the owner, the upload routes
- * through `pushIntoSharedFolder` (multi-key fan-out) so every folder
- * member receives an RSA-wrapped copy of the new file's
- * key. Owned folders take the existing single-key `push` path.
+ * Uploads into any folder of a shared tree route through
+ * `pushIntoSharedFolder` (multi-key fan-out) so every member receives an
+ * RSA-wrapped copy of the new file's key. The authorising member list is
+ * resolved once for the batch — the nearest ancestor-or-self with a
+ * signed list. Private folders take the single-key `push` path.
  */
 const uploadMany = async (files?: FileList, dirId?: string) => {
   if (!files) return
@@ -303,14 +303,10 @@ const uploadMany = async (files?: FileList, dirId?: string) => {
 
   if (files.length) {
     const parentFolder = dirId ? Storage.getItem(dirId) : null
-    // Use multi-key for any folder that's been shared, whether the
-    // caller owns it or not. Owner-side uploads to a private folder
-    // (no `members_signed_at`) stay on the regular create path because
-    // multi-key requires a signed member list to verify against.
-    const useMultiKey =
-      parentFolder !== null &&
-      parentFolder.mime === 'dir' &&
-      (parentFolder.is_owner === false || parentFolder.members_signed_at != null)
+    const rosterFolderId =
+      parentFolder !== null && parentFolder.mime === 'dir'
+        ? await Storage.writeRosterId(dirId)
+        : undefined
 
     for (let i = 0; i < files.length; i++) {
       try {
@@ -321,12 +317,13 @@ const uploadMany = async (files?: FileList, dirId?: string) => {
       }
 
       try {
-        if (useMultiKey && parentFolder) {
+        if (rosterFolderId !== undefined && parentFolder) {
           await Upload.pushIntoSharedFolder(
             props.keypair,
             files[i],
             parentFolder,
-            callerUserId
+            callerUserId,
+            { rosterFolderId }
           )
         } else {
           await Upload.push(props.keypair, files[i], dirId)
@@ -360,10 +357,10 @@ const browseFolder = () => {
  * Core folder upload logic. Takes a flat list of { file, relativePath } items,
  * creates the directory hierarchy as needed, then enqueues each file.
  *
- * A shared base directory pins the whole tree to the multi-key path: the
- * base folder's signed member list authorises every wrap, because the
- * directories created along the way inherit its roster but carry no
- * signed list of their own.
+ * A base directory inside a shared tree pins the whole batch to the
+ * multi-key path: the nearest signed member list above it authorises
+ * every wrap, because the directories created along the way inherit
+ * that roster but carry no signed list of their own.
  */
 async function uploadByPaths(
   items: { file: File; relativePath: string }[],
@@ -371,13 +368,7 @@ async function uploadByPaths(
 ) {
   const dirCache = new Map<string, string>()
 
-  const baseFolder = baseDir ? Storage.getItem(baseDir) : null
-  const sharedRootId =
-    baseFolder !== null &&
-    baseFolder.mime === 'dir' &&
-    (baseFolder.is_owner === false || baseFolder.members_signed_at != null)
-      ? baseFolder.id
-      : undefined
+  const sharedRootId = await Storage.writeRosterId(baseDir)
 
   // Shallowest paths first so parent dirs exist before children
   items.sort((a, b) => a.relativePath.split('/').length - b.relativePath.split('/').length)

--- a/web/src/layouts/components/LayoutFileBrowserInner.vue
+++ b/web/src/layouts/components/LayoutFileBrowserInner.vue
@@ -359,12 +359,25 @@ const browseFolder = () => {
 /**
  * Core folder upload logic. Takes a flat list of { file, relativePath } items,
  * creates the directory hierarchy as needed, then enqueues each file.
+ *
+ * A shared base directory pins the whole tree to the multi-key path: the
+ * base folder's signed member list authorises every wrap, because the
+ * directories created along the way inherit its roster but carry no
+ * signed list of their own.
  */
 async function uploadByPaths(
   items: { file: File; relativePath: string }[],
   baseDir: string | undefined
 ) {
   const dirCache = new Map<string, string>()
+
+  const baseFolder = baseDir ? Storage.getItem(baseDir) : null
+  const sharedRootId =
+    baseFolder !== null &&
+    baseFolder.mime === 'dir' &&
+    (baseFolder.is_owner === false || baseFolder.members_signed_at != null)
+      ? baseFolder.id
+      : undefined
 
   // Shallowest paths first so parent dirs exist before children
   items.sort((a, b) => a.relativePath.split('/').length - b.relativePath.split('/').length)
@@ -380,13 +393,20 @@ async function uploadByPaths(
         try {
           const existing = await meta.getByName(props.keypair, parts[i], currentParent)
           if (existing.mime === 'dir') {
+            Storage.upsertItem(existing)
             dirCache.set(pathKey, existing.id)
           } else {
             throw new Error(`"${parts[i]}" exists but is not a directory`)
           }
         } catch (e: any) {
           if (e?.status === 404) {
-            const dir = await Storage.createDir(props.keypair, parts[i], currentParent)
+            const dir = await Storage.createDir(
+              props.keypair,
+              parts[i],
+              currentParent,
+              props.authenticated.user.id,
+              sharedRootId
+            )
             Storage.upsertItem(dir)
             dirCache.set(pathKey, dir.id)
           } else {
@@ -404,13 +424,16 @@ async function uploadByPaths(
       if (
         parentFolder !== null &&
         parentFolder.mime === 'dir' &&
-        (parentFolder.is_owner === false || parentFolder.members_signed_at != null)
+        (sharedRootId !== undefined ||
+          parentFolder.is_owner === false ||
+          parentFolder.members_signed_at != null)
       ) {
         await Upload.pushIntoSharedFolder(
           props.keypair,
           file,
           parentFolder,
-          props.authenticated.user.id
+          props.authenticated.user.id,
+          { rosterFolderId: sharedRootId }
         )
       } else {
         await Upload.push(props.keypair, file, currentParent)
@@ -561,6 +584,7 @@ watch(
     v-model="isModalCreateDirActive"
     :Crypto="Crypto"
     :Storage="Storage"
+    :authenticated-user-id="props.authenticated.user.id"
     @cancel="isModalCreateDirActive = false"
   />
   <CreateFileModal

--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -1132,7 +1132,8 @@
       "roleReaderTitle": "Leser · darf nur ansehen, keine neuen Dateien hinzufügen",
       "sigFailed": "Signatur konnte nicht verifiziert werden",
       "sigLegacy": "Alte Zeile (ohne Signatur)",
-      "sigVerified": "Signatur verifiziert"
+      "sigVerified": "Signatur verifiziert",
+      "sigViaRoot": "Anhand der signierten Mitgliederliste des Freigabe-Stammordners verifiziert"
     },
     "modal": {
       "peopleEmpty": "Noch keine Konten mit Zugriff.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1132,7 +1132,8 @@
       "roleReaderTitle": "Reader · view only, cannot add new files",
       "sigFailed": "Signature did not verify",
       "sigLegacy": "Legacy row (no signature)",
-      "sigVerified": "Signature verified"
+      "sigVerified": "Signature verified",
+      "sigViaRoot": "Verified against the share root's signed member list"
     },
     "modal": {
       "peopleEmpty": "No accounts have access yet.",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -1132,7 +1132,8 @@
       "roleReaderTitle": "Lecteur · lecture seule, ne peut pas ajouter de fichiers",
       "sigFailed": "La signature n’a pas pu être vérifiée",
       "sigLegacy": "Ancienne entrée (sans signature)",
-      "sigVerified": "Signature vérifiée"
+      "sigVerified": "Signature vérifiée",
+      "sigViaRoot": "Vérifié selon la liste de membres signée de la racine du partage"
     },
     "modal": {
       "peopleEmpty": "Aucun compte n’a encore accès.",

--- a/web/src/locales/hr.json
+++ b/web/src/locales/hr.json
@@ -1132,7 +1132,8 @@
       "roleReaderTitle": "Čitatelj · samo pregled, ne može dodavati nove datoteke",
       "sigFailed": "Potpis nije prošao provjeru",
       "sigLegacy": "Stari zapis (bez potpisa)",
-      "sigVerified": "Potpis provjeren"
+      "sigVerified": "Potpis provjeren",
+      "sigViaRoot": "Provjereno prema potpisanom popisu članova korijena dijeljenja"
     },
     "modal": {
       "peopleEmpty": "Još nijedan račun nema pristup.",

--- a/web/src/views/files/index-view/TableFiles.vue
+++ b/web/src/views/files/index-view/TableFiles.vue
@@ -20,7 +20,7 @@ import BaseButton from '@/components/ui/BaseButton.vue'
 import { computed, ref, watch } from 'vue'
 import type { AppFile } from 'types'
 import { isPreviewable, isMarkdownFile } from '!/preview'
-import { SHARED_WITH_ME_DIR_ID } from '!/storage'
+import { SHARED_WITH_ME_DIR_ID, canWriteToShared } from '!/storage'
 
 const props = defineProps<{
   selected: AppFile[]
@@ -159,18 +159,18 @@ const showDownloadMany = computed(() => {
 const isSharedWithMeRoot = computed(() => props.parentId === SHARED_WITH_ME_DIR_ID)
 
 /**
- * Inside a shared folder (caller has a write share but doesn't own it),
- * file uploads go through the multi-key path. Creating a subdirectory
- * has no multi-key equivalent yet, so the directory affordance hides
- * until that endpoint exists — falling back to the regular create would
- * produce a `parent_directory_not_found` toast the user can't recover
- * from.
+ * Directory creation and folder upload work wherever the multi-key
+ * create can run: any folder the caller owns, and shared folders whose
+ * signed member list is available — the share root, where the caller
+ * holds a write role. Below the root a recipient has no verifiable
+ * roster, so those affordances stay hidden there.
  */
-const isSharedFolder = computed(() => {
+const canCreateDirHere = computed(() => {
   const d = props.dir
-  if (!d) return false
+  if (!d) return true
   if (d.mime !== 'dir') return false
-  return d.is_owner === false
+  if (d.is_owner !== false) return true
+  return d.members_signed_at != null && canWriteToShared(d)
 })
 
 const singleSelected = computed(() => {
@@ -356,7 +356,7 @@ const sizes = {
       :icon="mdiFolderPlusOutline"
       color="light"
       @click="emits('directory')"
-      v-if="!checkedRows.length && !isSharedWithMeRoot && !isSharedFolder"
+      v-if="!checkedRows.length && !isSharedWithMeRoot && canCreateDirHere"
     />
 
     <BaseButton
@@ -389,7 +389,7 @@ const sizes = {
       :icon="mdiFolderArrowUpOutline"
       color="light"
       @click="emits('browse-folder')"
-      v-if="!checkedRows.length && !isSharedWithMeRoot && !isSharedFolder"
+      v-if="!checkedRows.length && !isSharedWithMeRoot && canCreateDirHere"
     />
   </div>
 

--- a/web/src/views/files/index-view/TableFiles.vue
+++ b/web/src/views/files/index-view/TableFiles.vue
@@ -160,17 +160,17 @@ const isSharedWithMeRoot = computed(() => props.parentId === SHARED_WITH_ME_DIR_
 
 /**
  * Directory creation and folder upload work wherever the multi-key
- * create can run: any folder the caller owns, and shared folders whose
- * signed member list is available — the share root, where the caller
- * holds a write role. Below the root a recipient has no verifiable
- * roster, so those affordances stay hidden there.
+ * create can run: any folder the caller owns, and any folder shared
+ * with a write role — the create resolves the authorising member list
+ * from the nearest signed ancestor, so depth doesn't matter. Readers
+ * keep no write affordances.
  */
 const canCreateDirHere = computed(() => {
   const d = props.dir
   if (!d) return true
   if (d.mime !== 'dir') return false
   if (d.is_owner !== false) return true
-  return d.members_signed_at != null && canWriteToShared(d)
+  return canWriteToShared(d)
 })
 
 const singleSelected = computed(() => {

--- a/web/tests/save.test.ts
+++ b/web/tests/save.test.ts
@@ -453,6 +453,33 @@ describe('createNote into a shared folder', () => {
     expect(uploadIntoSharedFolder).not.toHaveBeenCalled()
     expect(metaCreate).toHaveBeenCalledTimes(1)
   })
+
+  it('UNIT: a resolved roster routes an owned unsigned parent through multi-key', async () => {
+    // A directory below the share root is owned by its creator and has no
+    // signed list of its own — the caller-resolved roster id is the only
+    // signal that the note belongs to a shared tree.
+    const parent = {
+      id: 'nested-dir-id',
+      mime: 'dir',
+      is_owner: true
+    } as unknown as AppFile
+    ;(metaGet as unknown as { mockResolvedValueOnce: (v: AppFile) => void }).mockResolvedValueOnce({
+      id: 'shared-file-id',
+      name: 'note.md'
+    } as unknown as AppFile)
+
+    await createNote(makeKeypair(), 'note', parent, 'caller-id', 'share-root-id')
+
+    expect(metaCreate).not.toHaveBeenCalled()
+    expect(uploadIntoSharedFolder).toHaveBeenCalledTimes(1)
+    const args = (
+      uploadIntoSharedFolder as unknown as {
+        mock: { calls: [{ payload: Record<string, unknown>; rosterFolderId?: string }][] }
+      }
+    ).mock.calls[0][0]
+    expect(args.payload.parentFileId).toBe('nested-dir-id')
+    expect(args.rosterFolderId).toBe('share-root-id')
+  })
 })
 
 describe('createDirInSharedFolder', () => {

--- a/web/tests/save.test.ts
+++ b/web/tests/save.test.ts
@@ -93,6 +93,7 @@ import {
   replaceContent,
   saveFileContent,
   createNote,
+  createDirInSharedFolder,
   needsMultikeyCreate,
   SaveConflictError
 } from '../services/storage/save'
@@ -451,5 +452,83 @@ describe('createNote into a shared folder', () => {
 
     expect(uploadIntoSharedFolder).not.toHaveBeenCalled()
     expect(metaCreate).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('createDirInSharedFolder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function makeKeypair(): KeyPair {
+    return {
+      publicKey: 'pub',
+      input: 'priv',
+      fingerprint: 'fp'
+    } as KeyPair
+  }
+
+  const parent = {
+    id: 'folder-id',
+    mime: 'dir',
+    is_owner: false,
+    share_role: 'editor'
+  } as unknown as AppFile
+
+  it('UNIT: fans the folder key out through uploadIntoSharedFolder', async () => {
+    ;(metaGet as unknown as { mockResolvedValueOnce: (v: AppFile) => void }).mockResolvedValueOnce({
+      id: 'shared-file-id',
+      mime: 'dir',
+      name: 'photos'
+    } as unknown as AppFile)
+
+    const created = await createDirInSharedFolder(makeKeypair(), 'photos', parent, 'caller-id')
+
+    expect(uploadIntoSharedFolder).toHaveBeenCalledTimes(1)
+    const args = (
+      uploadIntoSharedFolder as unknown as {
+        mock: { calls: [{ payload: Record<string, unknown>; rosterFolderId?: string }][] }
+      }
+    ).mock.calls[0][0]
+    expect(args.payload.mime).toBe('dir')
+    expect(args.payload.chunks).toBe(0)
+    expect(args.payload.size).toBeUndefined()
+    expect(args.payload.parentFileId).toBe('folder-id')
+    expect(args.rosterFolderId).toBeUndefined()
+    expect(searchTags).toHaveBeenCalledWith(expect.anything(), 'photos')
+    expect(metaCreate).not.toHaveBeenCalled()
+    expect(created.id).toBe('shared-file-id')
+  })
+
+  it('UNIT: pins the roster folder for creates below the share root', async () => {
+    ;(metaGet as unknown as { mockResolvedValueOnce: (v: AppFile) => void }).mockResolvedValueOnce({
+      id: 'shared-file-id',
+      mime: 'dir',
+      name: 'nested'
+    } as unknown as AppFile)
+
+    const intermediate = { ...parent, id: 'level-one-id', is_owner: true } as unknown as AppFile
+    await createDirInSharedFolder(
+      makeKeypair(),
+      'nested',
+      intermediate,
+      'caller-id',
+      'share-root-id'
+    )
+
+    const args = (
+      uploadIntoSharedFolder as unknown as {
+        mock: { calls: [{ payload: Record<string, unknown>; rosterFolderId?: string }][] }
+      }
+    ).mock.calls[0][0]
+    expect(args.payload.parentFileId).toBe('level-one-id')
+    expect(args.rosterFolderId).toBe('share-root-id')
+  })
+
+  it('UNIT: refuses to run without an active keypair', async () => {
+    await expect(
+      createDirInSharedFolder({ publicKey: 'pub' } as unknown as KeyPair, 'x', parent, 'caller-id')
+    ).rejects.toThrow('Cannot create directory without an active keypair')
+    expect(uploadIntoSharedFolder).not.toHaveBeenCalled()
   })
 })

--- a/web/tests/shares/editable.test.ts
+++ b/web/tests/shares/editable.test.ts
@@ -311,6 +311,104 @@ describe('editable folder upload pipeline', () => {
     expect(ownerOfFile[0].user_id).toEqual(UPLOADER_ID)
   })
 
+  it('upload_into_shared_folder_pins_roster_to_the_share_root', async () => {
+    // A create below the share root wraps against the root's signed list
+    // while targeting the real parent — the roster folder and the
+    // parent_file_id diverge on purpose.
+    const ROSTER_ID = '55555555-5555-5555-5555-555555555555'
+    const ownerKp = await cryptfns.rsa.generateKeyPair()
+    const { response, keypairs } = await buildResponse(ROSTER_ID, ownerKp, OWNER_ID, [
+      { user_id: OWNER_ID, email: 'a@example.com', role: 'co-owner', isOwner: true },
+      { user_id: UPLOADER_ID, email: 'b@example.com', role: 'editor' }
+    ])
+    const trusted = trustedFingerprintsStore()
+    trusted.bind(UPLOADER_ID)
+    trusted.trustFingerprint(OWNER_ID, response.folder_owner_pubkey_fingerprint, 'other')
+
+    const fetchedIds: string[] = []
+    let captured: UploadMultiKeyBody | null = null
+    await uploadIntoSharedFolder(
+      {
+        callerUserId: UPLOADER_ID,
+        callerPrivateKey: (keypairs.get(UPLOADER_ID) as KeyPair).input as string,
+        callerPublicKey: (keypairs.get(UPLOADER_ID) as KeyPair).publicKey as string,
+        payload: {
+          newFileId: NEW_FILE_ID,
+          parentFileId: FOLDER_ID,
+          fileKeyHex: 'aa'.repeat(16),
+          nameHash: 'h',
+          encryptedName: 'enc',
+          mime: 'dir',
+          chunks: 0,
+          cipher: 'aegis128l'
+        },
+        rosterFolderId: ROSTER_ID,
+        trustedFingerprints: trusted
+      },
+      {
+        fetchMembers: async (folderId) => {
+          fetchedIds.push(folderId)
+          return response
+        },
+        postUpload: async (body) => {
+          captured = body
+          return { file_id: NEW_FILE_ID }
+        }
+      }
+    )
+    expect(fetchedIds).toEqual([ROSTER_ID])
+    expect(captured!.parent_file_id).toEqual(FOLDER_ID)
+    expect(captured!.members_list_snapshot.members_list_signature).toEqual(
+      response.members_list_signature
+    )
+  })
+
+  it('upload_into_shared_folder_rejects_roster_for_a_different_folder', async () => {
+    // The list signature only authenticates the roster for the folder id
+    // inside the canonical — a response for any other folder, however
+    // validly signed, must not authorise the wraps.
+    const ownerKp = await cryptfns.rsa.generateKeyPair()
+    const { response, keypairs } = await buildResponse(
+      '66666666-6666-6666-6666-666666666666',
+      ownerKp,
+      OWNER_ID,
+      [
+        { user_id: OWNER_ID, email: 'a@example.com', role: 'co-owner', isOwner: true },
+        { user_id: UPLOADER_ID, email: 'b@example.com', role: 'editor' }
+      ]
+    )
+    const trusted = trustedFingerprintsStore()
+    trusted.bind(UPLOADER_ID)
+
+    await expect(
+      uploadIntoSharedFolder(
+        {
+          callerUserId: UPLOADER_ID,
+          callerPrivateKey: (keypairs.get(UPLOADER_ID) as KeyPair).input as string,
+          callerPublicKey: (keypairs.get(UPLOADER_ID) as KeyPair).publicKey as string,
+          payload: {
+            newFileId: NEW_FILE_ID,
+            parentFileId: FOLDER_ID,
+            fileKeyHex: 'bb'.repeat(16),
+            nameHash: 'h',
+            encryptedName: 'enc',
+            mime: 'text/plain',
+            size: 1,
+            chunks: 1,
+            cipher: 'aegis128l'
+          },
+          trustedFingerprints: trusted
+        },
+        {
+          fetchMembers: async () => response,
+          postUpload: async () => {
+            throw new Error('must not reach the server')
+          }
+        }
+      )
+    ).rejects.toMatchObject({ name: 'FolderMemberListInvalid', reason: 'folder_mismatch' })
+  })
+
   it('upload_into_shared_folder_signs_audit_event', async () => {
     const ownerKp = await cryptfns.rsa.generateKeyPair()
     const { response, keypairs } = await buildResponse(FOLDER_ID, ownerKp, OWNER_ID, [

--- a/web/tests/shares/editable.test.ts
+++ b/web/tests/shares/editable.test.ts
@@ -422,6 +422,7 @@ describe('editable folder upload pipeline', () => {
     ) as FolderMember
     trusted.trustFingerprint(THIRD_ID, thirdMember.pubkey_fingerprint, 'other')
     let attempts = 0
+    let fetches = 0
     const uploaderKp = first.keypairs.get(UPLOADER_ID) as KeyPair
     const result = await uploadIntoSharedFolder(
       {
@@ -442,7 +443,10 @@ describe('editable folder upload pipeline', () => {
         trustedFingerprints: trusted
       },
       {
-        fetchMembers: async () => first.response,
+        // The retry refetches the roster from its source rather than
+        // trusting the 409 payload, so the stub serves the live view:
+        // stale before the membership change, refreshed after it.
+        fetchMembers: async () => (++fetches === 1 ? first.response : refreshed.response),
         postUpload: async (body) => {
           attempts += 1
           if (attempts === 1) {
@@ -454,6 +458,7 @@ describe('editable folder upload pipeline', () => {
       }
     )
     expect(attempts).toBe(2)
+    expect(fetches).toBe(2)
     expect(result.file_id).toBe(NEW_FILE_ID)
   })
 
@@ -477,6 +482,7 @@ describe('editable folder upload pipeline', () => {
       return true
     })
     let attempts = 0
+    let fetches = 0
     const uploaderKp = first.keypairs.get(UPLOADER_ID) as KeyPair
     await uploadIntoSharedFolder(
       {
@@ -498,7 +504,7 @@ describe('editable folder upload pipeline', () => {
         onUnknownMember
       },
       {
-        fetchMembers: async () => first.response,
+        fetchMembers: async () => (++fetches === 1 ? first.response : refreshed.response),
         postUpload: async () => {
           attempts += 1
           if (attempts === 1) {

--- a/web/tests/shares/folder_members.test.ts
+++ b/web/tests/shares/folder_members.test.ts
@@ -546,4 +546,77 @@ describe('FolderMembersView', () => {
       wrapper.find(`[data-testid="folder-members-view-row-${COOWNER_ID}-revoke"]`).exists()
     ).toBe(false)
   })
+
+  it('folder_members_view_verifies_descendant_roster_against_share_root', async () => {
+    // A folder below the share root carries the root's roster but no
+    // signed list of its own — the view resolves the nearest signed
+    // ancestor and verifies against its list. A member the root's list
+    // doesn't cover gets a red badge; the rest verify "via root".
+    const CHILD_ID = '22222222-2222-2222-2222-222222222222'
+    const ROGUE_ID = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
+    const { response: rootResponse } = await buildSignedResponse()
+    const rogueKp = await cryptfns.rsa.generateKeyPair()
+    const rogue: FolderMember = {
+      user_id: ROGUE_ID,
+      email: 'mallory@example.com',
+      pubkey: rogueKp.publicKey as string,
+      key_type: 'rsa',
+      wrapping_pubkey: null,
+      pubkey_fingerprint: shareCrypto.computeFingerprint(rogueKp.publicKey as string),
+      share_role: 'reader',
+      is_owner: false,
+      added_at: 1_700_000_000,
+      signed_by_user_id: OWNER_ID,
+      member_signature: null
+    }
+    const childResponse: FolderMembersResponse = {
+      ...rootResponse,
+      folder_id: CHILD_ID,
+      members: [...rootResponse.members, rogue],
+      members_signed_at: null,
+      members_list_signature: null,
+      members_list_signed_by_user_id: null
+    }
+    vi.spyOn(sharesApi, 'getFolderMembers').mockImplementation(async (folderId: string) => {
+      if (folderId === CHILD_ID) return childResponse
+      if (folderId === FOLDER_ID) return rootResponse
+      throw new Error(`unexpected roster fetch for ${folderId}`)
+    })
+
+    const { store: storageStore } = await import('../../services/storage')
+    const files = storageStore()
+    files.addItem({ ...buildFolderFixture(), members_signed_at: 1_700_000_500 } as never)
+    files.addItem({
+      ...buildFolderFixture(),
+      id: CHILD_ID,
+      file_id: FOLDER_ID,
+      members_signed_at: undefined,
+      name: 'nested'
+    } as never)
+
+    const wrapper = mount(FolderMembersView, {
+      props: {
+        folder: files.getItem(CHILD_ID) as AppFile,
+        authenticatedUserId: OWNER_ID,
+        keypair: viewKeypair as KeyPair,
+        outgoingShares: []
+      }
+    })
+    await flushPromises()
+
+    expect(
+      wrapper.find(`[data-testid="folder-members-view-row-${EDITOR_ID}-sig-via-root"]`).exists()
+    ).toBe(true)
+    expect(
+      wrapper.find(`[data-testid="folder-members-view-row-${RESHARED_ID}-sig-via-root"]`).exists()
+    ).toBe(true)
+    expect(
+      wrapper.find(`[data-testid="folder-members-view-row-${ROGUE_ID}-sig-failed"]`).exists()
+    ).toBe(true)
+    expect(
+      wrapper.find(`[data-testid="folder-members-view-row-${EDITOR_ID}-sig-unsigned"]`).exists()
+    ).toBe(false)
+
+    wrapper.unmount()
+  })
 })

--- a/web/tests/shares/move_into_shared.test.ts
+++ b/web/tests/shares/move_into_shared.test.ts
@@ -330,6 +330,7 @@ describe('move folder cascade into shared folder', () => {
     )
 
     let attempts = 0
+    let fetches = 0
     await moveIntoSharedFolder(
       {
         callerUserId: CALLER_ID,
@@ -340,7 +341,9 @@ describe('move folder cascade into shared folder', () => {
         trustedFingerprints: trusted
       },
       {
-        fetchMembers: async () => first.response,
+        // The retry refetches the roster from its source rather than
+        // trusting the 409 payload — the stub serves the live view.
+        fetchMembers: async () => (++fetches === 1 ? first.response : refreshed.response),
         collectSubtree: async () => [root.node],
         postMove: async (body) => {
           attempts += 1
@@ -352,6 +355,7 @@ describe('move folder cascade into shared folder', () => {
       }
     )
     expect(attempts).toBe(2)
+    expect(fetches).toBe(2)
   })
 
   it('hard-stops on a tampered roster before any wrap', async () => {
@@ -539,6 +543,24 @@ describe('classifyMove decision tree', () => {
       sharingEnabled: true
     })
     expect(d).toMatchObject({ kind: 'into-shared', destinationFolderId: 'dest' })
+  })
+
+  it('routes into a folder below the share root via the resolved roster', () => {
+    // An owned, unsigned intermediate directory looks private to the
+    // `isSharedFolder` predicate; the caller-resolved roster id is what
+    // marks it as part of a shared tree and rides into the decision.
+    const d = classifyMove({
+      sources: [file('f1')],
+      destination: dir('nested'),
+      sourceParent: null,
+      sharingEnabled: true,
+      destinationRosterId: 'dest'
+    })
+    expect(d).toMatchObject({
+      kind: 'into-shared',
+      destinationFolderId: 'nested',
+      rosterFolderId: 'dest'
+    })
   })
 
   it('blocks the whole move when any source into a shared destination is not owned', () => {

--- a/web/tests/shares/storage_shared_with_me.test.ts
+++ b/web/tests/shares/storage_shared_with_me.test.ts
@@ -643,3 +643,122 @@ describe('Storage store: Shared with me virtual folder', () => {
     expect(row?.finished_upload_at).toBeUndefined()
   })
 })
+
+describe('Storage store: roster resolution for writes in shared trees', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  const ROOT = 'aaaa1111-1111-1111-1111-111111111111'
+  const MID = 'bbbb2222-2222-2222-2222-222222222222'
+  const LEAF = 'cccc3333-3333-3333-3333-333333333333'
+
+  function seedChain(
+    store: ReturnType<typeof storageStore>,
+    { rootSigned = true }: { rootSigned?: boolean } = {}
+  ): void {
+    store.addItem({
+      id: ROOT,
+      file_id: SHARED_WITH_ME_DIR_ID,
+      mime: 'dir',
+      is_owner: false,
+      share_role: 'editor',
+      members_signed_at: rootSigned ? 1_700_000_000 : undefined,
+      name: 'root'
+    } as never)
+    store.addItem({
+      id: MID,
+      file_id: ROOT,
+      mime: 'dir',
+      is_owner: false,
+      share_role: 'editor',
+      name: 'mid'
+    } as never)
+    store.addItem({
+      id: LEAF,
+      file_id: MID,
+      mime: 'dir',
+      is_owner: false,
+      share_role: 'editor',
+      name: 'leaf'
+    } as never)
+  }
+
+  it('resolves the folder itself when it carries a signed list', async () => {
+    const store = storageStore()
+    seedChain(store)
+    const resolved = await store.resolveRosterFolder(ROOT)
+    expect(resolved?.id).toEqual(ROOT)
+  })
+
+  it('walks the store up to the nearest signed ancestor', async () => {
+    const store = storageStore()
+    seedChain(store)
+    const find = vi.spyOn(meta, 'find')
+    const resolved = await store.resolveRosterFolder(LEAF)
+    expect(resolved?.id).toEqual(ROOT)
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('returns null for a private owned chain without fetching', async () => {
+    const store = storageStore()
+    store.addItem({
+      id: MID,
+      file_id: null,
+      mime: 'dir',
+      is_owner: true,
+      name: 'private-root'
+    } as never)
+    store.addItem({
+      id: LEAF,
+      file_id: MID,
+      mime: 'dir',
+      is_owner: true,
+      name: 'private-child'
+    } as never)
+    const find = vi.spyOn(meta, 'find')
+    expect(await store.resolveRosterFolder(LEAF)).toBeNull()
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('falls back to one breadcrumb fetch when the chain is not in the store', async () => {
+    const store = storageStore()
+    const find = vi.spyOn(meta, 'find').mockResolvedValue({
+      children: [],
+      parents: [
+        { id: ROOT, file_id: null, mime: 'dir', members_signed_at: 1_700_000_000 },
+        { id: MID, file_id: ROOT, mime: 'dir' },
+        { id: LEAF, file_id: MID, mime: 'dir' }
+      ]
+    } as unknown as Awaited<ReturnType<typeof meta.find>>)
+
+    const resolved = await store.resolveRosterFolder(LEAF)
+    expect(resolved?.id).toEqual(ROOT)
+    expect(find).toHaveBeenCalledTimes(1)
+    expect(find).toHaveBeenCalledWith({ dir_id: LEAF })
+  })
+
+  it('writeRosterId falls back to the folder itself for a legacy share', async () => {
+    const store = storageStore()
+    seedChain(store, { rootSigned: false })
+    // The unsigned chain resolves nothing, but the recipient row itself
+    // stays the roster source so the write keeps today's verification
+    // error instead of silently landing owner-only.
+    expect(await store.writeRosterId(LEAF)).toEqual(LEAF)
+    expect(await store.writeRosterId(ROOT)).toEqual(ROOT)
+  })
+
+  it('writeRosterId returns undefined for private folders and the virtual root', async () => {
+    const store = storageStore()
+    store.addItem({
+      id: MID,
+      file_id: null,
+      mime: 'dir',
+      is_owner: true,
+      name: 'mine'
+    } as never)
+    expect(await store.writeRosterId(MID)).toBeUndefined()
+    expect(await store.writeRosterId(SHARED_WITH_ME_DIR_ID)).toBeUndefined()
+    expect(await store.writeRosterId(undefined)).toBeUndefined()
+  })
+})

--- a/web/tests/shares/storage_shared_with_me.test.ts
+++ b/web/tests/shares/storage_shared_with_me.test.ts
@@ -428,6 +428,49 @@ describe('Storage store: Shared with me virtual folder', () => {
     expect(rows[0].file_id).toEqual(SHARED_WITH_ME_DIR_ID)
   })
 
+  it('storage_shared_folder_visited_before_virtual_listing_stays_single', async () => {
+    // The reverse order of the case above, reported in GH #202: Bob
+    // refreshes the page while inside shared folder X (a deep link or an
+    // email link does the same), so X lands in the store under its real
+    // parent before `__shared_with_me__` was ever listed. The virtual
+    // listing then added a second copy under the synthetic parent, and
+    // the next visit rewrote the stale copy's placement too — X rendered
+    // twice inside Shared with me from then on.
+    vi.spyOn(meta, 'decrypt').mockImplementation(async (item) => {
+      const id = (item as { id?: string }).id
+      if (id === '11111111-1111-1111-1111-111111111111') return { name: 'shared-x' }
+      return { name: '' }
+    })
+    vi.spyOn(meta, 'find').mockResolvedValue({
+      children: [],
+      parents: [
+        {
+          id: '11111111-1111-1111-1111-111111111111',
+          file_id: null,
+          is_owner: false,
+          mime: 'dir',
+          name: '',
+          encrypted_name: '',
+          encrypted_key: '',
+          cipher: 'aegis128l'
+        }
+      ]
+    } as unknown as Awaited<ReturnType<typeof meta.find>>)
+    vi.spyOn(sharesApi, 'getSharesMine').mockResolvedValue(makeIncomingPage())
+
+    const store = storageStore()
+    // Cold start straight inside X, then two visits to the virtual folder.
+    await store.find(KEYPAIR, '11111111-1111-1111-1111-111111111111')
+    await store.find(KEYPAIR, SHARED_WITH_ME_DIR_ID)
+    await store.find(KEYPAIR, SHARED_WITH_ME_DIR_ID)
+
+    const rows = store.items.filter(
+      (r) => r.id === '11111111-1111-1111-1111-111111111111'
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].file_id).toEqual(SHARED_WITH_ME_DIR_ID)
+  })
+
   it('storage_owned_root_excludes_previously_visited_shared_folder', async () => {
     // After clicking through `__shared_with_me__` into a shared folder X
     // and then back to the owned root via the sidebar Files entry, X


### PR DESCRIPTION
## What

Creating a folder inside an already-shared folder produced a directory only its creator could see: folder creation ran through the owner-only create, so no other member of the share ever received a wrapped copy of the folder key. Reported in #202 together with the same share showing up twice under "Shared with me". Two commits: the first fixes the reported symptoms at the share root, the second extends every multi-key write to work at any depth of a shared tree.

### Fix the reported symptoms

- Directory creation routes through `upload-multikey` when the parent is a shared folder — the same path file uploads and note creation already take, and the same request shape the mobile client sends. The New folder and folder-upload affordances appear for recipients with a write role.
- "Shared with me" no longer lists a share twice. The store checked row presence on (id, parent) but replaced rows on id alone, so a share first seen under its real parent — a search hit navigating straight into the folder — gained a second copy under the synthetic parent, and the next listing rewrote the stale copy in place. Rows are upserted by id alone now.
- A re-share of the parent already backfilled descendants the recipient was missing; an integration test pins that, alongside the server contract for `mime: "dir"` multi-key creates.

### Resolve write rosters at the nearest signed ancestor

Only share-mutation roots carry a signed member list, but the multi-key write path verified the direct parent's — so below the root, an owner's create silently took the owner-only path and a recipient's was refused with "no signature". Every write into a shared tree (creates, notes, uploads, folder uploads, moves) now resolves the nearest ancestor-or-self folder with a signed list, verifies that list, and wraps for its members while targeting the real parent. Rosters below a root are copies of the root's by construction, and the server already rejects any wrap set that doesn't match the target's rows, so a wrong resolution fails closed. No server changes.

- The roster fetch is bound to the folder it asked about: a response whose `folder_id` differs is refused — the list signature only authenticates the roster for the folder named inside the canonical, so any other validly signed roster of the same owner must not authorise the wraps.
- Membership-changed retries refetch from the roster source instead of trusting the 409 payload, which below a root carries no signature to verify.
- The members view applies the same resolution: a signature-less roster verifies against the resolved ancestor's list, so folders below a share root no longer read "Legacy row (no signature)".
- Pre-signature legacy shares keep their existing verification error.

The mobile client ships the mirrored change (same resolution, same binding check) so the two verifiers stay in lockstep.

Fixes #202

## Tests

- `cargo test --test shares_editable_folders --test shares_basic` — multi-key `mime: "dir"` contract including a second-level create below the share root; re-share backfill
- `yarn vitest run` — roster resolution walk and fallbacks, the roster pin, the folder-id binding refusal, retry-refetch modelling, the members-view ancestor verification, the "visited before the virtual listing" duplicate
- `just e2e shares-folder.spec.ts` — owner- and recipient-created folders visible to the other side at two depths; single listing after a search-hit entry
- `just ci-test` run in full before each push
